### PR TITLE
Fix for bug42526  Prominently indicate new location for renamed pages

### DIFF
--- a/WebContent/WEB-INF/templates/ViewPage.jsp
+++ b/WebContent/WEB-INF/templates/ViewPage.jsp
@@ -5,6 +5,7 @@
 
 <c:set var="lastEditAction">
   <c:choose>
+    <c:when test="${pageInfo.renamed}">Renamed</c:when>
     <c:when test="${pageInfo.deleted}">Deleted</c:when>
     <c:when test="${not pageInfo.newPage}">Last changed</c:when>
   </c:choose>
@@ -90,7 +91,12 @@
 	    </c:choose>
 	    <c:if test="${not empty lastEditAction}">
 		    <p>
-		      <a name="lastChanged" href="<c:url value="${encodedPageName}?revision=${pageInfo.lastChangedRevision}&amp;diff=${pageInfo.lastChangedRevision - 1}"/>">${lastEditAction} by <c:out value="${pageInfo.lastChangedUser}"/> on <f:formatDate type="both" value="${pageInfo.lastChangedDate}"/></a> <a name="history" href="<c:url value="${encodedPageName}?history"/>">[History]</a>
+		      <a name="lastChanged" href="<c:url value="${encodedPageName}?revision=${pageInfo.lastChangedRevision}&amp;diff=${pageInfo.lastChangedRevision - 1}"/>">${lastEditAction} by <c:out value="${pageInfo.lastChangedUser}"/> on <f:formatDate type="both" value="${pageInfo.lastChangedDate}"/></a>
+          <c:if test="${pageInfo.renamed}">
+            <c:set var="encodedRenamedPageName" value="${sw:urlEncode(pageInfo.renamedPageName)}"/>
+            <a name="renamedTo" href="<c:url value="${encodedRenamedPageName}"/>">[Renamed to ${encodedRenamedPageName}]</a>
+          </c:if>
+          <a name="history" href="<c:url value="${encodedPageName}?history"/>">[History]</a>
 		    </p>
 		  </c:if>
 		</div>

--- a/src/net/hillsdon/reviki/vc/ChangeInfo.java
+++ b/src/net/hillsdon/reviki/vc/ChangeInfo.java
@@ -41,8 +41,13 @@ public class ChangeInfo {
   private final ChangeType _changeType;
   private final String _copiedFrom;
   private final long _copiedFromRevision;
+  private final PageReference _renamedTo;
   
   public ChangeInfo(final String page, final String name, final String user, final Date date, final long revision, final String commitMessage, StoreKind kind, ChangeType changeType, String copiedFrom, long copiedFromRevision) {
+    this(page, name, user, date, revision, commitMessage, kind, changeType, copiedFrom, copiedFromRevision, null);
+  }
+
+  public ChangeInfo(final String page, final String name, final String user, final Date date, final long revision, final String commitMessage, StoreKind kind, ChangeType changeType, String copiedFrom, long copiedFromRevision, PageReference renamedTo) {
     _page = page;
     _name = name;
     _user = user;
@@ -53,6 +58,7 @@ public class ChangeInfo {
     _copiedFrom = copiedFrom;
     _copiedFromRevision = copiedFromRevision;
     _commitMessage = commitMessage == null ? null : commitMessage.trim();
+    _renamedTo = renamedTo;
   }
   
   public ChangeType getChangeType() {
@@ -132,6 +138,10 @@ public class ChangeInfo {
 
   public long getCopiedFromRevision() {
     return _copiedFromRevision;
+  }
+  
+  public PageReference getRenamedTo() {
+    return _renamedTo;
   }
   
 }

--- a/src/net/hillsdon/reviki/vc/TestPageInfo.java
+++ b/src/net/hillsdon/reviki/vc/TestPageInfo.java
@@ -16,6 +16,7 @@
 package net.hillsdon.reviki.vc;
 
 import junit.framework.TestCase;
+import net.hillsdon.reviki.vc.impl.PageReferenceImpl;
 import net.hillsdon.reviki.vc.impl.VersionedPageInfoImpl;
 
 public class TestPageInfo extends TestCase {
@@ -27,6 +28,14 @@ public class TestPageInfo extends TestCase {
     VersionedPageInfo committed = new VersionedPageInfoImpl("wiki", "name", "content", 5, 2, null, null, null, null, null);
     assertEquals("r2", committed.getRevisionName());
     assertFalse(committed.isNewPage());
+    assertFalse(committed.isRenamed());
+  }
+  
+  public void testRenamedPageNameIsRenamed() {
+    VersionedPageInfo renamed = new VersionedPageInfoImpl("wiki", "name", "content", VersionedPageInfo.RENAMED, 6, null, null, null, null, null, new PageReferenceImpl("/wiki/renamed"));
+    assertEquals(renamed.getRenamedPageName(), "renamed");
+    assertTrue(renamed.isNewPage());
+    assertTrue(renamed.isRenamed());
   }
   
 }

--- a/src/net/hillsdon/reviki/vc/VersionedPageInfo.java
+++ b/src/net/hillsdon/reviki/vc/VersionedPageInfo.java
@@ -28,6 +28,7 @@ public interface VersionedPageInfo extends PageInfo  {
   // Magic revisions.  Prefer isFoo() methods.
   long UNCOMMITTED = -2;
   long DELETED = -3;
+  long RENAMED = -4;
 
   long getRevision();
   String getRevisionName();
@@ -44,6 +45,8 @@ public interface VersionedPageInfo extends PageInfo  {
 
   boolean isNewPage();
   boolean isDeleted();
+  boolean isRenamed();
+  String getRenamedPageName();
 
   VersionedPageInfo withoutLockToken();
 

--- a/src/net/hillsdon/reviki/vc/impl/RepositoryBasicSVNOperations.java
+++ b/src/net/hillsdon/reviki/vc/impl/RepositoryBasicSVNOperations.java
@@ -174,6 +174,14 @@ public class RepositoryBasicSVNOperations implements BasicSVNOperations {
     String user = entry.getAuthor();
     Date date = entry.getDate();
     SVNLogEntryPath logForPath = (SVNLogEntryPath) entry.getChangedPaths().get(path);
+    
+    PageReference renamedTo = null;
+    for (Object entryPath : entry.getChangedPaths().values()) {
+      SVNLogEntryPath logEntryPath = (SVNLogEntryPath) entryPath;
+      if (ChangeType.forCode(logEntryPath.getType()).equals(ChangeType.ADDED) && path.equals(logEntryPath.getCopyPath())) {
+        renamedTo = new PageReferenceImpl(logEntryPath.getPath());
+      }
+    }
     String copiedFrom = logForPath.getCopyPath();
     long copiedFromRevision = -1;
     if (SVNPathUtil.isAncestor(rootPath, copiedFrom)) {
@@ -183,7 +191,7 @@ public class RepositoryBasicSVNOperations implements BasicSVNOperations {
     else {
       copiedFrom = null;
     }
-    return new ChangeInfo(page, name, user, date, entry.getRevision(), entry.getMessage(), kind, ChangeType.forCode(logForPath.getType()), copiedFrom, copiedFromRevision);
+    return new ChangeInfo(page, name, user, date, entry.getRevision(), entry.getMessage(), kind, ChangeType.forCode(logForPath.getType()), copiedFrom, copiedFromRevision, renamedTo);
   }
 
   public void unlock(final PageReference ref, final String lockToken) throws PageStoreAuthenticationException, PageStoreException {

--- a/src/net/hillsdon/reviki/vc/impl/SVNPageStore.java
+++ b/src/net/hillsdon/reviki/vc/impl/SVNPageStore.java
@@ -208,13 +208,18 @@ public class SVNPageStore extends AbstractPageStore {
       String lastChangedAuthor = null;
       Date lastChangedDate = null;
       final ChangeInfo deletingChange = getChangeThatDeleted(ref);
+      PageReference renamedTo = null;
       if (deletingChange != null) {
         pseudoRevision = VersionedPageInfo.DELETED;
         lastChangedRevision = deletingChange.getRevision();
         lastChangedAuthor = deletingChange.getUser();
         lastChangedDate = deletingChange.getDate();
+        renamedTo = deletingChange.getRenamedTo();
+        if (renamedTo != null) {
+          pseudoRevision = VersionedPageInfo.RENAMED;
+        }
       }
-      return new VersionedPageInfoImpl(_wiki, ref.getPath(), "", pseudoRevision, lastChangedRevision, lastChangedAuthor, lastChangedDate, null, null, null);
+      return new VersionedPageInfoImpl(_wiki, ref.getPath(), "", pseudoRevision, lastChangedRevision, lastChangedAuthor, lastChangedDate, null, null, null, renamedTo);
     }
     else {
       throw new PageStoreException(format("Unexpected node kind '%s' at '%s'", kind, ref));

--- a/src/net/hillsdon/reviki/vc/impl/VersionedPageInfoImpl.java
+++ b/src/net/hillsdon/reviki/vc/impl/VersionedPageInfoImpl.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import net.hillsdon.reviki.vc.PageReference;
 import net.hillsdon.reviki.vc.VersionedPageInfo;
 
 /**
@@ -30,6 +31,7 @@ public class VersionedPageInfoImpl extends PageInfoImpl implements VersionedPage
 
   public static final long UNCOMMITTED = -2;
   public static final long DELETED = -3;
+  public static final long RENAMED = -4;
 
   private final long _revision;
   private final long _lastChangedRevision;
@@ -39,9 +41,15 @@ public class VersionedPageInfoImpl extends PageInfoImpl implements VersionedPage
   private final String _lockedBy;
   private final String _lockToken;
   private final Date _lockedSince;
+  private PageReference _renamed;
 
   public VersionedPageInfoImpl(final String wiki, final String path, final String content, final long revision, final long lastChangedRevision, final String lastChangedAuthor, final Date lastChangedDate, final String lockedBy, final String lockToken, Date lockedSince) {
     this(wiki, path, content, revision, lastChangedRevision, lastChangedAuthor, lastChangedDate, lockedBy, lockToken, lockedSince, new LinkedHashMap<String, String>());
+  }
+
+  public VersionedPageInfoImpl(final String wiki, final String path, final String content, final long revision, final long lastChangedRevision, final String lastChangedAuthor, final Date lastChangedDate, final String lockedBy, final String lockToken, Date lockedSince, PageReference renamed) {
+    this(wiki, path, content, revision, lastChangedRevision, lastChangedAuthor, lastChangedDate, lockedBy, lockToken, lockedSince);
+    _renamed = renamed;
   }
 
   public VersionedPageInfoImpl(final String wiki, final String path, final String content, final long revision, final long lastChangedRevision, final String lastChangedAuthor, final Date lastChangedDate, final String lockedBy, final String lockToken, Date lockedSince, Map<String, String> attributes) {
@@ -105,11 +113,11 @@ public class VersionedPageInfoImpl extends PageInfoImpl implements VersionedPage
   }
 
   public boolean isNewPage() {
-    return _revision == UNCOMMITTED || _revision == DELETED;
+    return _revision == UNCOMMITTED || _revision == DELETED || _revision == RENAMED;
   }
 
   public boolean isDeleted() {
-    return _revision == DELETED;
+    return _revision == DELETED || _revision == RENAMED;
   }
 
   public boolean isNewOrLockedByUser(final String user) {
@@ -153,5 +161,13 @@ public class VersionedPageInfoImpl extends PageInfoImpl implements VersionedPage
       _lockedBy,
       "",
       _lockedSince);
+  }
+  
+  public boolean isRenamed() {
+    return _revision == RENAMED;
+  }
+  
+  public String getRenamedPageName() {
+    return _renamed.getName();
   }
 }

--- a/webtests/net/hillsdon/reviki/webtests/TestRename.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestRename.java
@@ -54,5 +54,20 @@ public class TestRename extends WebTestSupport {
     assertSearchDoesNotFindPage(page, fromPageName);
     editWikiPage(fromPageName, "This checks old page is new.", "", "Whatever", true);
   }
-
+  
+  public void testRenamedPageContainsNotification() throws Exception {
+    String fromPageName = uniqueWikiPageName("RenameTestFrom");
+    String toPageName = uniqueWikiPageName("RenameTestTo");
+    editWikiPage(fromPageName, "Catchy tunes", "", "Whatever", true);
+    
+    renamePage(fromPageName, toPageName);
+    HtmlPage fromPage = getWikiPage(fromPageName);
+    
+    assertTrue(fromPage.asText().contains(toPageName));
+    
+    // If fromPage is subsequently edited then we no longer show the notification
+    fromPage = editWikiPage(fromPageName, "another edit", "", "Whatever", false);
+    assertFalse(fromPage.asText().contains(toPageName));
+  }
+ 
 }


### PR DESCRIPTION
Display a link to the renamed page on pages that were renamed in their latest change.

Deleted pages are considered to be renamed if the SVN commit that deleted them also contains a new path that was copied from the path of the deleted location.

https://bugs.corefiling.com/show_bug.cgi?id=42526
