### PR TITLE
Fix for bug13835 Hyperlinks are rendered black in preview (instead of default colouring)

### DIFF
--- a/WebContent/resources/themes/reviki-flat/reviki-flat.css
+++ b/WebContent/resources/themes/reviki-flat/reviki-flat.css
@@ -126,9 +126,6 @@
   color: #222222;
 }
 
-.ui-widget-content a {
-  color: #222222;
-}
 
 .ui-widget-header {
   border: 1px solid #cccccc;


### PR DESCRIPTION
Do not define a custom CSS style for `a` tags in JQueryUI .ui-widget-content so that links have the same styling as wikipage content.

https://bugs.corefiling.com/show_bug.cgi?id=13835
