### PR TITLE
Fix for bug13502  Some invalid URLs (e.g. those with spaces in) are no longer supported in hyperlinks

### DIFF
--- a/src/net/hillsdon/reviki/wiki/renderer/creole/CreoleLinkContentsSplitter.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/CreoleLinkContentsSplitter.java
@@ -15,8 +15,10 @@
  */
 package net.hillsdon.reviki.wiki.renderer.creole;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.regex.MatchResult;
 
 import org.apache.commons.lang.StringUtils;
@@ -32,7 +34,9 @@ public class CreoleLinkContentsSplitter implements LinkContentSplitter {
    * Splits links of the form target or text|target where target is
    * 
    * PageName wiki:PageName PageName#fragment wiki:PageName#fragment
-   * scheme://valid/absolute/uri
+   * A String representing an absolute URI scheme://valid/absolute/uri
+   * Any character not in the `unreserved`, `punct`, `escaped`, or `other` categories (RFC 2396),
+   * and not equal '/' or '@', is %-encoded. 
    * 
    * @param in The String to split
    * @return The split LinkParts
@@ -49,12 +53,17 @@ public class CreoleLinkContentsSplitter implements LinkContentSplitter {
     // Link target can be PageName, wiki:PageName or a URL.
     URI uri = null;
     try {
-      uri = new URI(target);
+      URL url = new URL(target);
+      
+      uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
       if (uri.getPath()==null || !uri.isAbsolute()) {
         uri = null;
       }
     }
     catch (URISyntaxException e) {
+      // uri remains null
+    }
+    catch (MalformedURLException e) {
       // uri remains null
     }
 

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/TestCreoleLinkContentsSplitter.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/TestCreoleLinkContentsSplitter.java
@@ -7,7 +7,10 @@ import junit.framework.TestCase;
 public class TestCreoleLinkContentsSplitter extends TestCase {
 
   private static final String EXAMPLE_URI_STRING = "http://www.example.com/foo";
+  private static final String EXAMPLE_URI_STRING_RESERVED = "http://www.example.com/a b \\c";
+  private static final String EXAMPLE_URI_STRING_RESERVED_ESCAPED = "http://www.example.com/a%20b%20%5Cc";
   private static final URI EXAMPLE_URI = URI.create(EXAMPLE_URI_STRING);
+  private static final URI EXAMPLE_UNESCAPED_URI = URI.create(EXAMPLE_URI_STRING_RESERVED_ESCAPED);
   
   private CreoleLinkContentsSplitter _splitter;
   
@@ -30,6 +33,7 @@ public class TestCreoleLinkContentsSplitter extends TestCase {
   public void testExpectedInputsURI() {
     assertEquals(new LinkParts(EXAMPLE_URI_STRING, EXAMPLE_URI), _splitter.split(EXAMPLE_URI_STRING));
     assertEquals(new LinkParts("Some text", EXAMPLE_URI), _splitter.split(EXAMPLE_URI_STRING + "|" + "Some text"));
+    assertEquals(new LinkParts("Some text", EXAMPLE_UNESCAPED_URI), _splitter.split(EXAMPLE_URI_STRING_RESERVED + "|" + "Some text"));
   }
     
   public void testExpectedInputsWiki() {


### PR DESCRIPTION
Use the long form of java.net.URI constructor that quotes the path component of a URI string containing reserved characters (in the sense of RFC 2396).

This allows a user to specify an external link with the [[...]] syntax that contains a space character (for example).

https://bugs.corefiling.com/show_bug.cgi?id=13502
