### PR TITLE
Fix for bug 5949. Page rename should generate a useful commit message.

### DIFF
--- a/src/net/hillsdon/reviki/web/pages/impl/DefaultPageImpl.java
+++ b/src/net/hillsdon/reviki/web/pages/impl/DefaultPageImpl.java
@@ -160,6 +160,8 @@ public class DefaultPageImpl implements DefaultPage {
 
   public static final int MAX_NUMBER_OF_BACKLINKS_TO_DISPLAY = 15;
 
+  private static final String ATTR_FROM_PAGE = "fromPage";
+
   private final CachingPageStore _store;
 
   private final MarkupRenderer _renderer;
@@ -490,6 +492,7 @@ public class DefaultPageImpl implements DefaultPage {
     }
     else if (hasRenameParam) {
       final PageReference toPage = new PageReferenceImpl(getRequiredString(request, PARAM_TO_PAGE));
+      request.setAttribute(ATTR_FROM_PAGE, page.getName());
       try {
         _store.rename(page, toPage, -1, createLinkingCommitMessage(toPage, request));
       }
@@ -602,9 +605,14 @@ public class DefaultPageImpl implements DefaultPage {
   String createLinkingCommitMessage(final PageReference page, final HttpServletRequest request) {
     boolean minorEdit = request.getParameter(PARAM_MINOR_EDIT) != null;
     String commitMessage = request.getParameter(PARAM_COMMIT_MESSAGE);
-    if (commitMessage == null || commitMessage.trim().length() == 0) {
+    if (request.getParameter(SUBMIT_RENAME) != null) {
+      commitMessage = String.format("%s renamed to %s", request.getAttribute(ATTR_FROM_PAGE), page.getName());
+    }
+    else if (commitMessage == null || commitMessage.trim().length() == 0) {
       commitMessage = ChangeInfo.NO_COMMENT_MESSAGE_TAG;
     }
+    
+
     return (minorEdit ? ChangeInfo.MINOR_EDIT_MESSAGE_TAG : "") + commitMessage + "\n" + _wikiUrls.page(null, page.getName());
   }
 

--- a/src/net/hillsdon/reviki/web/pages/impl/TestDefaultPageImplSet.java
+++ b/src/net/hillsdon/reviki/web/pages/impl/TestDefaultPageImplSet.java
@@ -226,7 +226,7 @@ public class TestDefaultPageImplSet extends TestCase {
   public void testRenameTo() throws Exception {
     _request.setParameter(DefaultPageImpl.SUBMIT_RENAME, "");
     _request.setParameter(DefaultPageImpl.PARAM_TO_PAGE, TO_PAGE.getPath());
-    expect(_store.rename(CALLED_ON_PAGE, TO_PAGE, -1, "[reviki commit]\n" + _wikiUrls.page(null, TO_PAGE.getName()))).andReturn(2L).once();
+    expect(_store.rename(CALLED_ON_PAGE, TO_PAGE, -1, String.format("%s renamed to %s\n%s",  CALLED_ON_PAGE, TO_PAGE, _wikiUrls.page(null, TO_PAGE.getName())))).andReturn(2L).once();
     replay();
     RedirectToPageView view = (RedirectToPageView) _page.set(CALLED_ON_PAGE, ConsumedPath.EMPTY, _request, _response);
     assertEquals(TO_PAGE, view.getPage());

--- a/webtests/net/hillsdon/reviki/webtests/TestRename.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestRename.java
@@ -17,8 +17,12 @@ package net.hillsdon.reviki.webtests;
 
 import static net.hillsdon.reviki.webtests.TestAttachments.getTextAttachmentAtEndOfLink;
 
+import java.util.List;
+
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlTableRow;
 
 
 /**
@@ -53,6 +57,21 @@ public class TestRename extends WebTestSupport {
 
     assertSearchDoesNotFindPage(page, fromPageName);
     editWikiPage(fromPageName, "This checks old page is new.", "", "Whatever", true);
+  }
+  
+  @SuppressWarnings("unchecked")
+  public void testRenameCommitMessage() throws Exception {
+    String fromPageName = uniqueWikiPageName("RenameTestFrom");
+    String toPageName = uniqueWikiPageName("RenameTestTo");
+    HtmlPage page = editWikiPage(fromPageName, "Catchy tunes", "", "Whatever", true);
+    page = renamePage(fromPageName, toPageName);
+    
+    HtmlPage history = (HtmlPage) ((HtmlAnchor) page.getByXPath("//a[@name='history']").iterator().next()).click();
+    List<HtmlTableRow> historyRows = (List<HtmlTableRow>) history.getByXPath("//tr[td]");
+    assertEquals(3, historyRows.size());
+    HtmlTableRow renameInfo = historyRows.get(1);
+    assertTrue(renameInfo.getCell(3).asText().contains(fromPageName));
+    assertTrue(renameInfo.getCell(3).asText().contains(toPageName));
   }
 
 }


### PR DESCRIPTION
Add a useful commit message when a page is renamed.

https://bugs.corefiling.com/show_bug.cgi?id=5949
