### PR TITLE
Fix for 2014-04-30 WAT autocomplete bug

### DIFF
--- a/WebContent/resources/common.js
+++ b/WebContent/resources/common.js
@@ -122,6 +122,7 @@ reviki.configureAutoSuggest = function() {
       searchForm.submit();
       return false;
     },
+    appendTo: searchBox.parent(),
     html: true
   });
   


### PR DESCRIPTION
Append the autocomplete widget to the searchBox in the page DOM.

The searchBox is now contained in a position:fixed container element (as a result of the UI redesign). By
default the autocomplete widget is appended to the body of the page, and
so becomes disconnected from the searchBox when the page is scrolled. Using the autocomplete 'appendTo:' option we now append the widget to the searchBox so it remains attached when the page is scrolled.
