### PR TITLE
Fix for 2014-04-30 WAT inline nowiki rendering bug

### DIFF
--- a/WebContent/resources/default-style.css
+++ b/WebContent/resources/default-style.css
@@ -152,6 +152,14 @@ code {
   color: rgb(147,147,147); background-color: rgb(247,247,247); font-style: italic; font-weight: bold;
 }
 
+code.wiki-content {
+  font-size: 90%;
+  color: inherit;
+  background-color: inherit;
+  white-space: nowrap;
+  font-family: monospace;
+}
+
 div#MarkupHelp {
   background-color: white; color: #333;
   font-family: Verdana, Arial, Helvetica, sans-serif; line-height: 1.3em;


### PR DESCRIPTION
Alter CSS for <code/> tags so that inline nowiki markup looks similar to the previous version.
The font-size/background style is inherited to match the style of the enclosing tag (<h1>, <h2>, <body> etc.).
