### PR TITLE
Additional fix for bug10370. Autosave

### DIFF
--- a/WebContent/resources/common.js
+++ b/WebContent/resources/common.js
@@ -315,16 +315,22 @@ reviki.removeUnlockOnUnload = function() {
 }
 
 reviki.displayEditRestore = function() {
-  if (this.hasStoredData() && $("#preview-area").length != 1) {
+  if (this.hasStoredData() && this.browserStorage.get("reviki.restore.url") == document.URL && $("#preview-area").length != 1) {
     $("#restore").removeClass("hidden");
     }
   return false;
+}
+
+reviki.onSaveFormData = function() {
+  this.browserStorage.set("reviki.restore.url", document.URL);
+  $("#restore").addClass("hidden");
 }
 
 reviki.setupLeaveConfirm = function() {
   if ($("[name='editForm']").length == 1) {
     var storedForm = $("[name='editForm']").sisyphus({autoRelease: false,
                                              onBeforeRestore: reviki.displayEditRestore,
+                                             onSave: reviki.onSaveFormData,
                                              excludeFields: $("[type='hidden']")});
 
     if ($("#preview-area").length == 1) {


### PR DESCRIPTION
Only show the edit form restore button where the value of 'reviki.restore.url' in browser local storage is equal to the URL of the current page. (This prevents edits for one page from being restored to another).
- After a page edit, the previous state of the page cannot be restored, so remove the restore button.

https://bugs.corefiling.com/show_bug.cgi?id=10370
