### PR TITLE
Anchors

### DIFF
--- a/src/net/hillsdon/reviki/wiki/renderer/creole/Creole.g4
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/Creole.g4
@@ -93,6 +93,7 @@ inline     : inlinestep+ ;
 
 inlinestep : bold | italic | sthrough
            | link | titlelink | simpleimg | imglink | wikiwlink | attachment | rawlink
+           | anchor
            | inlinecode | preformat
            | linebreak
            | macro
@@ -118,6 +119,8 @@ wikiwlink  : WikiWords ;
 attachment : Attachment ;
 
 rawlink    : RawUrl ;
+
+anchor     : AnSt InAnchor AnEnd ;
 
 preformat  : NoWiki EndNoWikiInline ;
 

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -185,6 +185,7 @@ StartXml   : '[<xml>]'   -> mode(XML_INLINE) ;
 
 LiSt  : '[[' -> mode(LINK) ;
 ImSt  : '{{' -> mode(LINK) ;
+AnSt  : '[[#' -> mode(ANCHOR) ;
 
 /* ***** Breaks ***** */
 
@@ -252,6 +253,12 @@ InLinkEnd : (~('\r'|'\n'|']'|'}') | (']' ~']' | '}' ~'}'))+ {doLinkEnd();} ;
 
 LiEnd2 : (']]' | '\r'? '\n') -> mode(DEFAULT_MODE) ;
 ImEnd2 : ('}}' | '\r'? '\n') -> mode(DEFAULT_MODE) ;
+
+mode ANCHOR;
+
+InAnchor : ~('#'|']')+ ;
+
+AnEnd : ']]' -> mode(DEFAULT_MODE);
 
 mode MACRO;
 

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
@@ -180,6 +180,14 @@ public class Visitor extends CreoleASTBuilder {
   }
 
   /**
+   * Render an anchor.
+   */
+  @Override
+  public ASTNode visitAnchor(AnchorContext ctx) {
+    return new Anchor(ctx.InAnchor().getText());
+  }
+
+  /**
    * Render bold nodes, with error recovery by {@link #renderInline}.
    */
   @Override

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/ast/ASTVisitor.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/ast/ASTVisitor.java
@@ -8,7 +8,7 @@ package net.hillsdon.reviki.wiki.renderer.creole.ast;
 public abstract class ASTVisitor<T> {
   /** Enum of node types */
   public static enum NodeTypes {
-    ASTNode,
+    ASTNode, Anchor,
     BlockableNode, Bold,
     Code,
     Heading, HorizontalRule,
@@ -31,6 +31,7 @@ public abstract class ASTVisitor<T> {
   public T visit(ASTNode node) {
     // This doesn't include the abstract node types, as they can't be instantiated.
     switch(NodeTypes.valueOf(node.getClass().getSimpleName())) {
+      case Anchor:          return visitAnchor((Anchor) node);
       case Bold:            return visitBold((Bold) node);
       case Code:            return visitCode((Code) node);
       case Heading:         return visitHeading((Heading) node);
@@ -68,6 +69,7 @@ public abstract class ASTVisitor<T> {
    */
   public abstract T visitASTNode(ASTNode node);
 
+  public T visitAnchor(Anchor node)                   { return visitASTNode(node); }
   public T visitBlockableNode(BlockableNode node)     { return visitASTNode((ASTNode) node); }
   public T visitBold(Bold node)                       { return visitASTNode(node); }
   public T visitCode(Code node)                       { return visitASTNode(node); }

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/ast/Anchor.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/ast/Anchor.java
@@ -1,0 +1,18 @@
+package net.hillsdon.reviki.wiki.renderer.creole.ast;
+
+import net.hillsdon.fij.text.Escape;
+
+public class Anchor extends TaggedNode {
+  private final String _anchor;
+
+  public Anchor(final String anchor) {
+    super("a");
+
+    _anchor = anchor;
+  }
+
+  @Override
+  public String toXHTML() {
+    return String.format("<a %s id='%s'></a>", CSS_CLASS_ATTR, Escape.html(_anchor));
+  }
+}


### PR DESCRIPTION
(this depends on pull request #21)

This pull request implements inline anchor tags, denoted `[[#anchortext]]`, which render as `<a id="anchortext"></a>`. This makes links starting with a "#" no longer valid, as they'll get turned into anchor definitions - but this behaviour doesn't break anything.

This fixes REVIKI-400.
