### PR TITLE
Table markup

### DIFF
--- a/src/net/hillsdon/reviki/wiki/renderer/creole/ContextSensitiveLexer.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/ContextSensitiveLexer.java
@@ -103,6 +103,25 @@ public abstract class ContextSensitiveLexer extends Lexer {
   }
 
   /**
+   * Find the prior character on this line which was not whitespace. Returns
+   * null if there is no such character.
+   */
+  public Character priorNonWS() {
+    Character out = null;
+    int len = getText().length();
+
+    for (int i = 1; true; i++) {
+      Character chr = get(-len - i).charAt(0);
+      if (chr != ' ' && chr != '\t') {
+        out = chr;
+        break;
+      }
+    }
+
+    return out;
+  }
+
+  /**
    * Helper method for {@link #get(int)}, which gets the last character of the
    * token.
    */

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/Creole.g4
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/Creole.g4
@@ -83,8 +83,8 @@ hrule      : Rule ;
 table      : (trow (RowEnd | LineBreak))* trow (RowEnd | LineBreak)? ;
 trow       : tcell+ ;
 tcell      : th | td ;
-th         : ThStart inTable? ;
-td         : TdStart inTable? ;
+th         : ThStart inTable+ ;
+td         : TdStart inTable+ ;
 
 inTable    : {disallowBreaks();} (ulist | olist | code | nowiki | inline) {unsetBreaks();} ;
 

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -238,7 +238,7 @@ fragment DIGIT : ('0'..'9') ;
 
 // 'START' matches something which is start-of-line-like. Currently that's upon
 // entering a list item or table cell
-fragment START : {start}? | {intr && (prior() == '|' || prior() == '=')}? | LINE ;
+fragment START : {start}? | {intr && (priorNonWS() == '|' || priorNonWS() == '=')}? | LINE ;
 fragment LINE  : {getCharPositionInLine()==0}? (' '|'\t')*;
 
 /* ***** Contextual stuff ***** */

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
@@ -224,8 +224,8 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitTitlelink(final TitlelinkContext ctx) {
-    String target = (ctx.InLink()    == null) ? ""     : ctx.InLink().getText();
-    String title  = (ctx.InLinkEnd() == null) ? target : ctx.InLinkEnd().getText();
+    String target = (ctx.InLink() == null) ? "" : ctx.InLink().getText();
+    String title = (ctx.InLinkEnd() == null) ? target : ctx.InLinkEnd().getText();
     return new Link(target, title, page(), urlOutputFilter(), linkHandler());
   }
 
@@ -234,8 +234,8 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitImglink(final ImglinkContext ctx) {
-    String target = (ctx.InLink()    == null) ? ""     : ctx.InLink().getText();
-    String title  = (ctx.InLinkEnd() == null) ? target : ctx.InLinkEnd().getText();
+    String target = (ctx.InLink() == null) ? "" : ctx.InLink().getText();
+    String title = (ctx.InLinkEnd() == null) ? target : ctx.InLinkEnd().getText();
     return new Image(target, title, page(), urlOutputFilter(), imageHandler());
   }
 
@@ -536,8 +536,12 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitTh(final ThContext ctx) {
-    ASTNode inner = (ctx.inTable() != null) ? visit(ctx.inTable()) : null;
-    return new TableHeaderCell((inner != null) ? inner : new Plaintext(""));
+    List<ASTNode> inner = new ArrayList<ASTNode>();
+    for (InTableContext itx : ctx.inTable()) {
+      inner.add(visit(itx));
+    }
+
+    return new TableHeaderCell(inner);
   }
 
   /**
@@ -545,8 +549,12 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitTd(final TdContext ctx) {
-    ASTNode inner = (ctx.inTable() != null) ? visit(ctx.inTable()) : null;
-    return new TableCell((inner != null) ? inner : new Plaintext(""));
+    List<ASTNode> inner = new ArrayList<ASTNode>();
+    for (InTableContext itx : ctx.inTable()) {
+      inner.add(visit(itx));
+    }
+
+    return new TableCell(inner);
   }
 
   /**

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/ast/TableCell.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/ast/TableCell.java
@@ -1,7 +1,9 @@
 package net.hillsdon.reviki.wiki.renderer.creole.ast;
 
+import java.util.List;
+
 public class TableCell extends TaggedNode {
-  public TableCell(final ASTNode body) {
-    super("td", body);
+  public TableCell(final List<ASTNode> children) {
+    super("td", children);
   }
 }

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/ast/TableHeaderCell.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/ast/TableHeaderCell.java
@@ -1,7 +1,9 @@
 package net.hillsdon.reviki.wiki.renderer.creole.ast;
 
+import java.util.List;
+
 public class TableHeaderCell extends TaggedNode {
-  public TableHeaderCell(final ASTNode body) {
-    super("th", body);
+  public TableHeaderCell(final List<ASTNode> contents) {
+    super("th", contents);
   }
 }


### PR DESCRIPTION
(this depends on pull request #21)

Allow lists, code, nowiki, and plain text inside table cells. Table cells cannot contain single-item lists, to preserve backwards compatibility.

Example:

```
|* Foo
* Bar
** Baz|world|{{{look
some
code}}}|
|=And I didn't|=break|=tables|
```

Plain text still cannot contain linebreaks, nor can blocks be followed by trailing linebreaks---that still breaks the table. However, linebreaks can exist where allowed by the containing element: to start new list items, to embed content within list items, inside code/nowiki, following a `\\`, etc.

This goes part way towards fixing REVIKI-341.
