### PR TITLE
Fix REVIKI-491

### DIFF
--- a/src/net/hillsdon/reviki/wiki/renderer/SvnWikiLinkPartHandler.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/SvnWikiLinkPartHandler.java
@@ -29,6 +29,8 @@ import net.hillsdon.reviki.web.urls.UnknownWikiException;
 import net.hillsdon.reviki.wiki.renderer.creole.LinkParts;
 import net.hillsdon.reviki.wiki.renderer.creole.LinkPartsHandler;
 import net.hillsdon.reviki.wiki.renderer.creole.LinkResolutionContext;
+import net.hillsdon.reviki.wiki.renderer.creole.LinkTarget;
+import net.hillsdon.reviki.wiki.renderer.creole.PageLinkTarget;
 
 public class SvnWikiLinkPartHandler implements LinkPartsHandler {
 
@@ -104,7 +106,8 @@ public class SvnWikiLinkPartHandler implements LinkPartsHandler {
     String noFollow = link.isNoFollow(resolver) ? "rel='nofollow' " : "";
     String clazz = link.getStyleClass(resolver);
     String url = link.getURL(resolver);
-    if (!link.exists(resolver) && WikiWordUtils.isAcronym(link.getText())) {
+    LinkTarget target = link.getTarget();
+    if (target instanceof PageLinkTarget && !link.exists(resolver) && WikiWordUtils.isAcronym(((PageLinkTarget)target).getPageName())) {
       return link.getText();
     }
 

--- a/src/net/hillsdon/reviki/wiki/renderer/creole/LinkParts.java
+++ b/src/net/hillsdon/reviki/wiki/renderer/creole/LinkParts.java
@@ -46,6 +46,10 @@ public class LinkParts {
     return _text;
   }
 
+  public LinkTarget getTarget() {
+    return _target;
+  }
+
   @Override
   public String toString() {
     return getClass().getSimpleName() + Arrays.asList(_text, _target).toString();


### PR DESCRIPTION
The problem was that the link text (the title) was being checked, rather than the target, and so if a page didn't exist, and the title was in block capitals, Reviki decided it wasn't a real link.
