### PR TITLE
REVIKI-592 - Reviki Jira plugin issue link generation is too aggressive

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -193,6 +193,8 @@
 
   <target name="unit-tests" depends="compile" description="Run the unit tests">
     <junit printsummary="yes" fork="true" forkmode="once" haltonfailure="yes">
+      <jvmarg value="-Xss512k" />
+      <jvmarg value="-XX:ThreadStackSize=2048" />
       <formatter type="plain" usefile="false"/>
       <classpath>
         <path refid="classpath"/>

--- a/renderer-src/net/hillsdon/reviki/text/TestWikiWordUtils.java
+++ b/renderer-src/net/hillsdon/reviki/text/TestWikiWordUtils.java
@@ -104,6 +104,9 @@ public class TestWikiWordUtils extends TestCase {
   public void testIsAcronym() {
     assertTrue(WikiWordUtils.isAcronym("TLA"));
     assertTrue(WikiWordUtils.isAcronym("TLAs"));
+    assertTrue(WikiWordUtils.isAcronym("FOO-1"));
+    assertTrue(WikiWordUtils.isAcronym("FOO-1-BAR-BAZ"));
+    assertFalse(WikiWordUtils.isAcronym("FOO--1"));
     assertFalse(WikiWordUtils.isAcronym("TLAss"));
   }
 

--- a/renderer-src/net/hillsdon/reviki/text/WikiWordUtils.java
+++ b/renderer-src/net/hillsdon/reviki/text/WikiWordUtils.java
@@ -129,7 +129,7 @@ public final class WikiWordUtils {
   }
 
   public static boolean isAcronym(final String pageName) {
-    return pageName != null && pageName.matches("\\p{Lu}+s?");
+    return pageName != null && pageName.matches("\\p{Lu}([\\p{Lu}\\d]|(-[\\p{Lu}\\d]))+s?");
   }
 
 }

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -208,7 +208,7 @@ WikiWords : (UPPER (ABBR | CAMEL) REVISION? | INTERWIKI IWTARGET+) NOTALNUM {pri
 
 fragment IWTARGET  : ALNUM (('.' | '-') ALNUM)? ;
 fragment INTERWIKI : ALPHA ALNUM+ ':' ;
-fragment ABBR      : UPPER UPPER+ ;
+fragment ABBR      : UPPER (UPNUM | ('-' UPNUM))+ ;
 fragment CAMEL     : (LOWNUM* UPNUM ALNUM* LOWER ALNUM* | ALNUM* LOWER ALNUM* UPNUM+) ;
 fragment REVISION  : '?revision=' DIGIT+ ;
 

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
@@ -5,6 +5,21 @@
     "output": "<p><a class='inter-wiki' href='http://www.example.com/foo/Wiki?1234'>foo:1234</a></p>"
   },
   {
+    "name":   "Plain WikiWord",
+    "input":  "WikiWord",
+    "output": "<p><a rel='nofollow' class='new-page' href='http://www.example.com/reviki/pages/test-wiki/WikiWord'>WikiWord</a></p>"
+  },
+  {
+    "name":   "Abbrieviation - page doesn't exist",
+    "input":  "ABC",
+    "output": "<p>ABC</p>"
+  },
+  {
+    "name":   "Abbrieviation with hyphen - page doesn't exist",
+    "input":  "ABC-123",
+    "output": "<p>ABC-123</p>"
+  },
+  {
     "name":   "Raw HTML",
     "input":  "[<html>]\n<div class='unusual'></div>\n[</html>]",
     "output": "\n<div class='unusual'></div>\n"


### PR DESCRIPTION
A change to renderer grammar so that abbreviations may now contain internal hyphens and digits. 