### PR TITLE
REVIKI-569 - Introduce a terser alternative to [<blockquote>]

### DIFF
--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Creole.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Creole.g4
@@ -22,6 +22,7 @@ block     : heading
           | hrule
           | table
           | code | nowiki
+          | terseblockquote
           | blockquote
           | directive
           | paragraph
@@ -90,6 +91,8 @@ td         : TdStart inTable* ;
 inTable    : {disallowBreaks();} (ulist | olist | code | nowiki | inline) {unsetBreaks();} ;
 
 nowiki     : NoWiki EndNoWikiBlock ;
+
+terseblockquote : TerseBlockquote creole TerseBlockquote ;
 
 blockquote : BlockquoteSt creole BlockquoteEnd ;
 

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -232,6 +232,8 @@ DirectiveDisable : '<<-' -> mode(MACRO) ;
 BlockquoteSt  : '[<blockquote>]' ;
 BlockquoteEnd : '[</blockquote>]' ;
 
+TerseBlockquote : '"""' ;
+
 /* ***** Miscellaneous ***** */
 
 Any : ALNUM+ | . ;

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
@@ -575,6 +575,14 @@ public class Visitor extends CreoleASTBuilder {
   }
 
   /**
+   * Render a terseblockquote.
+   */
+  @Override
+  public ASTNode visitTerseblockquote(TerseblockquoteContext ctx) {
+    return new Blockquote(visit(ctx.creole()));
+  }
+
+  /**
    * Render a blockquote.
    */
   @Override

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
@@ -145,6 +145,21 @@
     "output": "<blockquote><p>Quoted text</p></blockquote>"
   },
   {
+    "name":   "Terse Blockquotes",
+    "input":  "\"\"\"Quoted text\"\"\"",
+    "output": "<blockquote><p>Quoted text</p></blockquote>"
+  },
+  {
+    "name":   "Terse Blockquotes subcreole",
+    "input":  "\"\"\"Quoted **text**\"\"\"",
+    "output": "<blockquote><p>Quoted <strong>text</strong></p></blockquote>"
+  },
+  {
+    "name":   "Terse Blockquotes context",
+    "input":  "preparagraph \"\"\"Quoted text\"\"\" postparagraph",
+    "output": "<p>preparagraph</p><blockquote><p>Quoted text</p></blockquote><p>postparagraph</p>"
+  },
+  {
     "name":   "Formatting inside tables",
     "input":  "|* Foo\n* Bar\n** Baz|world|{{{look\nsome\ncode}}}|\n|=Table|=header|=cells|",
     "output": "<table><tr><td><ul><li>Foo</li><li>Bar<ul><li>Baz</li></ul></li></ul></td><td>world</td><td><pre>look\nsome\ncode</pre></td></tr><tr><th>Table</th><th>header</th><th>cells</th></tr></table>"


### PR DESCRIPTION
Introduce a new blockquote syntax, markup surrounded by """

This works in the same way as the existing `[<blockquote>][</blockquote>]`
syntax.

https://jira.int.corefiling.com/browse/REVIKI-569