### PR TITLE
REVIKI-611 Prevent the terseblockquote rule from matching other blockquotes ahead in the text

### DIFF
--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Creole.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Creole.g4
@@ -92,7 +92,7 @@ inTable    : {disallowBreaks();} (ulist | olist | code | nowiki | inline) {unset
 
 nowiki     : NoWiki EndNoWikiBlock ;
 
-terseblockquote : TerseBlockquote creole TerseBlockquote ;
+terseblockquote : TerseBlockquoteSt creole TerseBlockquoteEnd ;
 
 blockquote : BlockquoteSt creole BlockquoteEnd ;
 

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -20,6 +20,10 @@ options { superClass=ContextSensitiveLexer; }
 
   public boolean jiraStyleLinks = false;
 
+  // track when we are in a terseblock quote so the we match start and
+  // end tokens correctly.
+  public boolean inTerseBlockquote = false;
+
   public CreoleTokens(CharStream input, boolean jiraStyleLinks) {
     this(input);
     this.jiraStyleLinks = jiraStyleLinks;
@@ -232,7 +236,8 @@ DirectiveDisable : '<<-' -> mode(MACRO) ;
 BlockquoteSt  : '[<blockquote>]' ;
 BlockquoteEnd : '[</blockquote>]' ;
 
-TerseBlockquote : '"""' ;
+TerseBlockquoteSt  : {!inTerseBlockquote}? '"""' {inTerseBlockquote = true;};
+TerseBlockquoteEnd : {inTerseBlockquote}? '"""' {inTerseBlockquote = false;};
 
 /* ***** Miscellaneous ***** */
 

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
@@ -160,6 +160,11 @@
     "output": "<p>preparagraph</p><blockquote><p>Quoted text</p></blockquote><p>postparagraph</p>"
   },
   {
+    "name":   "multiple Terse Blockquotes",
+    "input":  "\"\"\"first\"\"\"\n\"\"\"second\"\"\"",
+    "output": "<blockquote><p>first</p></blockquote><blockquote><p>second</p></blockquote>"
+  },
+  {
     "name":   "Formatting inside tables",
     "input":  "|* Foo\n* Bar\n** Baz|world|{{{look\nsome\ncode}}}|\n|=Table|=header|=cells|",
     "output": "<table><tr><td><ul><li>Foo</li><li>Bar<ul><li>Baz</li></ul></li></ul></td><td>world</td><td><pre>look\nsome\ncode</pre></td></tr><tr><th>Table</th><th>header</th><th>cells</th></tr></table>"


### PR DESCRIPTION
The terseblockquote rule matches arbitrary creole (as the markup in the
blockquote is rendered as creole) so this can match other blockquotes,
causing unintended nesting.

The solution used here is to have separate tokens for the start and end
of a terseblockquote in a way that just one blockquote can be matched at a
time.

NB: A lexer mode can't be used for this because the body of the quote
needs to be lexed with all rules from the default mode.

https://jira.int.corefiling.com/browse/REVIKI-611