### PR TITLE
Generate different AST nodes for nowiki, code and inline{code, nowiki}

### DIFF
--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/HtmlRenderer.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/HtmlRenderer.java
@@ -116,6 +116,11 @@ public class HtmlRenderer extends CreoleBasedRenderer<String> {
     }
 
     @Override
+    public String visitNowiki(final Nowiki node) {
+      return String.format("<pre %s>%s</pre>", CSS_CLASS_ATTR, Escape.html(node.getText()));
+    }
+
+    @Override
     public String visitHeading(final Heading node) {
       return renderTagged("h" + node.getLevel(), Optional.of(node));
     }
@@ -141,15 +146,19 @@ public class HtmlRenderer extends CreoleBasedRenderer<String> {
 
     @Override
     public String visitInlineCode(final InlineCode node) {
-      String out = "";
-      if (node.getLanguage().isPresent()) {
-        out += "<code class='wiki-content inline'>";
-      } else {
-        out += "<code " + CSS_CLASS_ATTR + ">";
+      String codeClass;
+      if (node.getLanguage().isPresent() && !node.getLanguage().get().isEmpty()) {
+        codeClass = " " + node.getLanguage().get();
       }
-      out += Escape.html(node.getText());
-      out += "</code>";
-      return out;
+      else {
+        codeClass = "";
+      }
+      return String.format("<code class='wiki-content inline%s'>%s</code>", codeClass, Escape.html(node.getText()));
+    }
+
+    @Override
+    public String visitInlineNowiki(final InlineNowiki node) {
+      return String.format("<code>%s</code>", Escape.html(node.getText()));
     }
 
     @Override

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -403,7 +403,10 @@ CodeEnd : '```' -> mode(DEFAULT_MODE) ;
 
 mode CODE_INLINE;
 
-CodeInlineAny : ~('`' | '\n' | '\r')+ ;
+CodeInlineAny : .*? ('`' | LineBreak) {seek(-1);} -> mode(CODE_INLINE_END) ;
+
+mode CODE_INLINE_END;
+
 CodeInlineEnd : ('`' | LineBreak) -> mode(DEFAULT_MODE) ;
 
 // Helper token types, not directly matched, but seta s the type of other tokens.

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
@@ -244,7 +244,7 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitPreformat(final PreformatContext ctx) {
-    return new InlineCode(ctx.NoWikiInlineAny().getText());
+    return new InlineNowiki(ctx.NoWikiInlineAny().getText());
   }
 
   /**
@@ -433,7 +433,7 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitNowiki(final NowikiContext ctx) {
-    return new Code(ctx.NoWikiAny().getText());
+    return new Nowiki(ctx.NoWikiAny().getText());
   }
 
   /**
@@ -464,7 +464,7 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitInlinecodeblock(final InlinecodeblockContext ctx) {
-    return new InlineCode(ctx.CodeInlineAny().getText(), "");
+    return new InlineCode(ctx.CodeInlineAny().getText());
   }
 
   /**

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/ASTVisitor.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/ASTVisitor.java
@@ -10,7 +10,7 @@ public abstract class ASTVisitor<T> {
   public static enum NodeTypes {
     ASTNode, Anchor,
     BlockableNode, Blockquote, Bold,
-    Code,
+    Code, Nowiki, InlineNowiki,
     DirectiveNode,
     Heading, HorizontalRule,
     Image, Inline, InlineCode, Italic,
@@ -37,12 +37,14 @@ public abstract class ASTVisitor<T> {
       case Blockquote:      return visitBlockquote((Blockquote) node);
       case Bold:            return visitBold((Bold) node);
       case Code:            return visitCode((Code) node);
+      case Nowiki:          return visitNowiki((Nowiki) node);
       case DirectiveNode:   return visitDirectiveNode((DirectiveNode) node);
       case Heading:         return visitHeading((Heading) node);
       case HorizontalRule:  return visitHorizontalRule((HorizontalRule) node);
       case Image:           return visitImage((Image) node);
       case Inline:          return visitInline((Inline) node);
       case InlineCode:      return visitInlineCode((InlineCode) node);
+      case InlineNowiki:    return visitInlineNowiki((InlineNowiki) node);
       case Italic:          return visitItalic((Italic) node);
       case Linebreak:       return visitLinebreak((Linebreak) node);
       case Link:            return visitLink((Link) node);
@@ -79,11 +81,13 @@ public abstract class ASTVisitor<T> {
   public T visitBlockquote(Blockquote node)                 { return visitASTNode(node); }
   public T visitBold(final Bold node)                       { return visitASTNode(node); }
   public T visitCode(final Code node)                       { return visitASTNode(node); }
+  public T visitNowiki(final Nowiki node)                   { return visitASTNode(node); }
   public T visitDirectiveNode(final DirectiveNode node)     { return visitASTNode(node); }
   public T visitHeading(final Heading node)                 { return visitASTNode(node); }
   public T visitHorizontalRule(final HorizontalRule node)   { return visitASTNode(node); }
   public T visitInline(final Inline node)                   { return visitASTNode(node); }
   public T visitInlineCode(final InlineCode node)           { return visitASTNode(node); }
+  public T visitInlineNowiki(final InlineNowiki node)       { return visitASTNode(node); }
   public T visitItalic(final Italic node)                   { return visitASTNode(node); }
   public T visitLinebreak(final Linebreak node)             { return visitASTNode(node); }
   public T visitListItem(final ListItem node)               { return visitASTNode(node); }

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/InlineCode.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/InlineCode.java
@@ -2,7 +2,7 @@ package net.hillsdon.reviki.wiki.renderer.creole.ast;
 
 import com.google.common.base.Optional;
 
-public class InlineCode extends TextNode implements BlockableNode<Code> {
+public class InlineCode extends TextNode {
   private final Optional<String> _language;
 
   public InlineCode(final String contents, final String language) {
@@ -15,15 +15,6 @@ public class InlineCode extends TextNode implements BlockableNode<Code> {
     super(contents, true);
 
     _language = Optional.<String>absent();
-  }
-
-  public Code toBlock() {
-    if (_language == null) {
-      return new Code(getText());
-    }
-    else {
-      return _language.isPresent() ? new Code(getText(), _language.get()) : new Code(getText());
-    }
   }
 
   public Optional<String> getLanguage() {

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/InlineNowiki.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/InlineNowiki.java
@@ -1,0 +1,12 @@
+package net.hillsdon.reviki.wiki.renderer.creole.ast;
+
+public class InlineNowiki extends TextNode implements BlockableNode<Nowiki> {
+
+  public InlineNowiki(final String contents) {
+    super(contents, true);
+  }
+
+  public Nowiki toBlock() {
+    return new Nowiki(getText());
+  }
+}

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/Nowiki.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/Nowiki.java
@@ -1,0 +1,28 @@
+package net.hillsdon.reviki.wiki.renderer.creole.ast;
+
+import java.util.List;
+
+import net.hillsdon.reviki.wiki.renderer.macro.Macro;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+
+public class Nowiki extends TextNode {
+  private final String _contents;
+
+  public Nowiki(final String contents) {
+    super(contents, true);
+
+    _contents = contents;
+  }
+
+  @Override
+  public List<ASTNode> expandMacrosInt(final Supplier<List<Macro>> macros) {
+    return ImmutableList.of((ASTNode) this);
+  }
+
+  @Override
+  public String getText() {
+    return _contents;
+  }
+}

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/core-creole.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/core-creole.json
@@ -294,7 +294,7 @@
   {
     "name":   "Inline syntax highlighting",
     "input":  "Look at this [<java>]System.out.println(\"code!\");[</java>]",
-    "output": "<p>Look at this <code class='wiki-content inline'>System.out.println(&quot;code!&quot;);</code></p>"
+    "output": "<p>Look at this <code class='wiki-content inline java'>System.out.println(&quot;code!&quot;);</code></p>"
   },
   {
     "name":   "Block syntax highlighting",

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
@@ -50,6 +50,21 @@
     "output": "<p>Some text <code class='wiki-content inline'>System.out.print(&quot;Hello, &quot;);</code>end text</p>"
   },
   {
+    "name":   "Inline syntax highlighting at beginning of line with no other content",
+    "input":  "`System.out.print(\"Hello, \");`",
+    "output": "<p><code class='wiki-content inline'>System.out.print(&quot;Hello, &quot;);</code></p>"
+  },
+  {
+    "name":   "Inline syntax highlighting empty",
+    "input":  "``",
+    "output": ""
+  },
+  {
+    "name":   "Inline syntax highlighting single followed by newline",
+    "input":  "`\n",
+    "output": ""
+  },
+  {
     "name":   "Image link vs no wiki",
     "input":  "Hello {{{//there//}}}.",
     "output": "<p>Hello <code>//there//</code>.</p>"


### PR DESCRIPTION
Nowiki markup in a line containing other markup is rendered as inline
nowiki. eg
"""
text {{{inline}}}
"""

And nowik markup on a single line is rendered as a block:
"""
{{{block}}}
"""

In contrast we wish to render single backtick delimited codeblocks inline, even if they're the only text on the line.

To do this the parser must generate different AST nodes for code and
nowiki blocks.

This commit also includes a change to the lexer so that single backtick
delimited codeblocks may have empty content.

https://jira.int.corefiling.com/browse/REVIKI-587