### PR TITLE
REVIKI-587 - Improved code highlighting

### DIFF
--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/HtmlRenderer.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/HtmlRenderer.java
@@ -116,6 +116,11 @@ public class HtmlRenderer extends CreoleBasedRenderer<String> {
     }
 
     @Override
+    public String visitNowiki(final Nowiki node) {
+      return String.format("<pre %s>%s</pre>", CSS_CLASS_ATTR, Escape.html(node.getText()));
+    }
+
+    @Override
     public String visitHeading(final Heading node) {
       return renderTagged("h" + node.getLevel(), Optional.of(node));
     }
@@ -141,15 +146,19 @@ public class HtmlRenderer extends CreoleBasedRenderer<String> {
 
     @Override
     public String visitInlineCode(final InlineCode node) {
-      String out = "";
-      if (node.getLanguage().isPresent()) {
-        out += "<code class='wiki-content inline'>";
-      } else {
-        out += "<code " + CSS_CLASS_ATTR + ">";
+      String codeClass;
+      if (node.getLanguage().isPresent() && !node.getLanguage().get().isEmpty()) {
+        codeClass = " " + node.getLanguage().get();
       }
-      out += Escape.html(node.getText());
-      out += "</code>";
-      return out;
+      else {
+        codeClass = "";
+      }
+      return String.format("<code class='wiki-content inline%s'>%s</code>", codeClass, Escape.html(node.getText()));
+    }
+
+    @Override
+    public String visitInlineNowiki(final InlineNowiki node) {
+      return String.format("<code>%s</code>", Escape.html(node.getText()));
     }
 
     @Override

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -104,6 +104,12 @@ options { superClass=ContextSensitiveLexer; }
     }
   }
 
+  public void doStartCodeLine() {
+    String startTag = "```";
+    seek(0 - (getText().length() - (getText().indexOf(startTag) + startTag.length()))); 
+    setText("");
+  }
+
   // Determine which tokens can, at this stage, break out of any inline
   // formatting.
   public java.util.List<String> thisKillsTheFormatting() {
@@ -218,8 +224,12 @@ CodeTagStart : '[<' CODETAGTYPE '>]' {doCodeTagStart(CODETAG_INLINE);} ;
 HtmlStart  : '[<html>]' {doCodeTagStart(HTML_INLINE);} ;
 
 /* ***** Code formatting ***** */
+// The rules match in this order: CodeBlockLine, CodeStartEOF, CodeStart, NoCodeStart, CodeInlineStart
 
-// The rules match in this order: CodeStartEOF, CodeStart, NoCodeStart, CodeInlineStart
+// We accept inline codeblocks without language hints.
+// (LineBreak EOF?)? ensures that this rule matches before CodeStartEOF or CodeStart
+// We strip off the initial ``` and whitespace before processing as a CODE_BLOCK
+CodeBlockLine : WS* '```' ~('\n' | '\r')* '```' WS* (LineBreak EOF?)? {doStartCodeLine();} -> mode(CODE_BLOCK), type(CodeStart);
 
 // Ignore codeblocks that start immediately before EOF
 CodeStartEOF : WS* '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak EOF -> type(Any) ;

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -403,7 +403,10 @@ CodeEnd : '```' -> mode(DEFAULT_MODE) ;
 
 mode CODE_INLINE;
 
-CodeInlineAny : ~('`' | '\n' | '\r')+ ;
+CodeInlineAny : .*? ('`' | LineBreak) {seek(-1);} -> mode(CODE_INLINE_END) ;
+
+mode CODE_INLINE_END;
+
 CodeInlineEnd : ('`' | LineBreak) -> mode(DEFAULT_MODE) ;
 
 // Helper token types, not directly matched, but seta s the type of other tokens.

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -229,12 +229,12 @@ HtmlStart  : '[<html>]' {doCodeTagStart(HTML_INLINE);} ;
 // We accept inline codeblocks without language hints.
 // (LineBreak EOF?)? ensures that this rule matches before CodeStartEOF or CodeStart
 // We strip off the initial ``` and whitespace before processing as a CODE_BLOCK
-CodeBlockLine : WS* '```' ~('\n' | '\r')* '```' WS* (LineBreak EOF?)? {doStartCodeLine();} -> mode(CODE_BLOCK), type(CodeStart);
+CodeBlockLine : (START | WS*) '```' ~('\n' | '\r')* '```' WS* (LineBreak EOF?)? {doStartCodeLine();} -> mode(CODE_BLOCK), type(CodeStart);
 
 // Ignore codeblocks that start immediately before EOF
-CodeStartEOF : WS* '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak EOF -> type(Any) ;
+CodeStartEOF : START '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak EOF -> type(Any) ;
 
-CodeStart : WS* '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak {setText(getText().trim().substring(3));} -> mode(CODE_BLOCK) ;
+CodeStart : START '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak {setText(getText().trim().substring(3));} -> mode(CODE_BLOCK) ;
 NoCodeStart: '```' -> type(Any) ;
 CodeInlineStart : '`' -> mode(CODE_INLINE) ;
 

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -408,7 +408,7 @@ CodeEof : . -> mode(CODE_BLOCK_EOF), more ;
 
 mode CODE_BLOCK_EOF;
 
-CodeToEof : .* EOF {seek(-1);} -> type(CodeAny), mode(CODE_BLOCK_EOF_END);
+CodeToEof : .*? EOF {seek(-1);} -> type(CodeAny), mode(CODE_BLOCK_EOF_END);
 
 mode CODE_BLOCK_END;
 

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -209,12 +209,12 @@ Bold   : '**' {toggleFormatting(bold, Any);} ;
 Italic : '//' {prior() == null || (prior() != ':' || !Character.isLetterOrDigit(priorprior()))}? {toggleFormatting(italic, Any);} ;
 Strike : '--' {toggleFormatting(strike, Any);} ;
 
-NoWiki     : '{{{'       -> mode(NOWIKI_INLINE) ;
+NoWiki : '{{{' -> mode(NOWIKI_INLINE) ;
 
 fragment CODETAGTYPE : 'c++' | 'java' | 'xhtml' | 'xml' ;
 fragment CODETAGTYPEHTML : CODETAGTYPE | 'html';
 
-CodeTagStart  : '[<' CODETAGTYPE '>]' {doCodeTagStart(CODETAG_INLINE);} ;
+CodeTagStart : '[<' CODETAGTYPE '>]' {doCodeTagStart(CODETAG_INLINE);} ;
 HtmlStart  : '[<html>]' {doCodeTagStart(HTML_INLINE);} ;
 
 /* ***** Code formatting ***** */
@@ -225,7 +225,7 @@ HtmlStart  : '[<html>]' {doCodeTagStart(HTML_INLINE);} ;
 CodeStartEOF : WS* '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak EOF -> type(Any) ;
 
 CodeStart : WS* '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak {setText(getText().trim().substring(3));} -> mode(CODE_BLOCK) ;
-NoCodeStart: '```' -> type(Any);
+NoCodeStart: '```' -> type(Any) ;
 CodeInlineStart : '`' -> mode(CODE_INLINE) ;
 
 /* ***** Links ***** */
@@ -362,7 +362,7 @@ NoWikiInlineAny : INLINE*? '}}}' {seek(-3);} -> mode(NOWIKI_END);
 
 mode NOWIKI_BLOCK;
 
-NoWikiAny      : .*? '}}}' {seek(-3);} -> mode(NOWIKI_END);
+NoWikiAny : .*? '}}}' {seek(-3);} -> mode(NOWIKI_END);
 
 mode NOWIKI_END;
 
@@ -381,7 +381,7 @@ CodeTagInlineAny : INLINE*? '[</' CODETAGTYPE '>]' {doEndCodeTag();} ;
 
 mode CODETAG_BLOCK;
 
-CodeTagAny    : .*? ENDCODETAG {doEndCodeTag();} ;
+CodeTagAny : .*? ENDCODETAG {doEndCodeTag();} ;
 
 mode CODETAG_END;
 
@@ -395,7 +395,7 @@ HtmlInlineAny : INLINE*? '[</html>]' {doEndCodeTag();} ;
 
 mode HTML_BLOCK;
 
-HtmlAny    : .*? '[</html>]' {doEndCodeTag();} ;
+HtmlAny : .*? '[</html>]' {doEndCodeTag();} ;
 
 // ***** Code
 

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/CreoleTokens.g4
@@ -222,7 +222,7 @@ HtmlStart  : '[<html>]' {doCodeTagStart(HTML_INLINE);} ;
 // The rules match in this order: CodeStartEOF, CodeStart, NoCodeStart, CodeInlineStart
 
 // Ignore codeblocks that start immediately before EOF
-CodeStartEOF : WS* '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak EOF -> more ;
+CodeStartEOF : WS* '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak EOF -> type(Any) ;
 
 CodeStart : WS* '```' ~(' ' | '\t' | '\r' | '\n')* WS* LineBreak {setText(getText().trim().substring(3));} -> mode(CODE_BLOCK) ;
 NoCodeStart: '```' -> type(Any);

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
@@ -244,7 +244,7 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitPreformat(final PreformatContext ctx) {
-    return new InlineCode(ctx.NoWikiInlineAny().getText());
+    return new InlineNowiki(ctx.NoWikiInlineAny().getText());
   }
 
   /**
@@ -433,7 +433,7 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitNowiki(final NowikiContext ctx) {
-    return new Code(ctx.NoWikiAny().getText());
+    return new Nowiki(ctx.NoWikiAny().getText());
   }
 
   /**
@@ -464,7 +464,7 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitInlinecodeblock(final InlinecodeblockContext ctx) {
-    return new InlineCode(ctx.CodeInlineAny().getText(), "");
+    return new InlineCode(ctx.CodeInlineAny().getText());
   }
 
   /**

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/Visitor.java
@@ -449,14 +449,7 @@ public class Visitor extends CreoleASTBuilder {
    */
   @Override
   public ASTNode visitCodeblock(final CodeblockContext ctx) {
-    // For some reason the codeblock rule matches when the markup has a
-    // trailing CodeStart token // (with no CodeAny or CodeEnd) so check for
-    // null CodeAny before processing.
-    if (ctx.CodeAny() != null) {
-      return new Code(ctx.CodeAny().getText(), ctx.CodeStart().getText().trim());
-    } else {
-      return new Plaintext("```");
-    }
+    return new Code(ctx.CodeAny().getText(), ctx.CodeStart().getText().trim());
   }
 
   /**

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/ASTVisitor.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/ASTVisitor.java
@@ -10,7 +10,7 @@ public abstract class ASTVisitor<T> {
   public static enum NodeTypes {
     ASTNode, Anchor,
     BlockableNode, Blockquote, Bold,
-    Code,
+    Code, Nowiki, InlineNowiki,
     DirectiveNode,
     Heading, HorizontalRule,
     Image, Inline, InlineCode, Italic,
@@ -37,12 +37,14 @@ public abstract class ASTVisitor<T> {
       case Blockquote:      return visitBlockquote((Blockquote) node);
       case Bold:            return visitBold((Bold) node);
       case Code:            return visitCode((Code) node);
+      case Nowiki:          return visitNowiki((Nowiki) node);
       case DirectiveNode:   return visitDirectiveNode((DirectiveNode) node);
       case Heading:         return visitHeading((Heading) node);
       case HorizontalRule:  return visitHorizontalRule((HorizontalRule) node);
       case Image:           return visitImage((Image) node);
       case Inline:          return visitInline((Inline) node);
       case InlineCode:      return visitInlineCode((InlineCode) node);
+      case InlineNowiki:    return visitInlineNowiki((InlineNowiki) node);
       case Italic:          return visitItalic((Italic) node);
       case Linebreak:       return visitLinebreak((Linebreak) node);
       case Link:            return visitLink((Link) node);
@@ -79,11 +81,13 @@ public abstract class ASTVisitor<T> {
   public T visitBlockquote(Blockquote node)                 { return visitASTNode(node); }
   public T visitBold(final Bold node)                       { return visitASTNode(node); }
   public T visitCode(final Code node)                       { return visitASTNode(node); }
+  public T visitNowiki(final Nowiki node)                   { return visitASTNode(node); }
   public T visitDirectiveNode(final DirectiveNode node)     { return visitASTNode(node); }
   public T visitHeading(final Heading node)                 { return visitASTNode(node); }
   public T visitHorizontalRule(final HorizontalRule node)   { return visitASTNode(node); }
   public T visitInline(final Inline node)                   { return visitASTNode(node); }
   public T visitInlineCode(final InlineCode node)           { return visitASTNode(node); }
+  public T visitInlineNowiki(final InlineNowiki node)       { return visitASTNode(node); }
   public T visitItalic(final Italic node)                   { return visitASTNode(node); }
   public T visitLinebreak(final Linebreak node)             { return visitASTNode(node); }
   public T visitListItem(final ListItem node)               { return visitASTNode(node); }

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/InlineCode.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/InlineCode.java
@@ -2,7 +2,7 @@ package net.hillsdon.reviki.wiki.renderer.creole.ast;
 
 import com.google.common.base.Optional;
 
-public class InlineCode extends TextNode implements BlockableNode<Code> {
+public class InlineCode extends TextNode {
   private final Optional<String> _language;
 
   public InlineCode(final String contents, final String language) {
@@ -15,15 +15,6 @@ public class InlineCode extends TextNode implements BlockableNode<Code> {
     super(contents, true);
 
     _language = Optional.<String>absent();
-  }
-
-  public Code toBlock() {
-    if (_language == null) {
-      return new Code(getText());
-    }
-    else {
-      return _language.isPresent() ? new Code(getText(), _language.get()) : new Code(getText());
-    }
   }
 
   public Optional<String> getLanguage() {

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/InlineNowiki.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/InlineNowiki.java
@@ -1,0 +1,12 @@
+package net.hillsdon.reviki.wiki.renderer.creole.ast;
+
+public class InlineNowiki extends TextNode implements BlockableNode<Nowiki> {
+
+  public InlineNowiki(final String contents) {
+    super(contents, true);
+  }
+
+  public Nowiki toBlock() {
+    return new Nowiki(getText());
+  }
+}

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/Nowiki.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/ast/Nowiki.java
@@ -1,0 +1,28 @@
+package net.hillsdon.reviki.wiki.renderer.creole.ast;
+
+import java.util.List;
+
+import net.hillsdon.reviki.wiki.renderer.macro.Macro;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+
+public class Nowiki extends TextNode {
+  private final String _contents;
+
+  public Nowiki(final String contents) {
+    super(contents, true);
+
+    _contents = contents;
+  }
+
+  @Override
+  public List<ASTNode> expandMacrosInt(final Supplier<List<Macro>> macros) {
+    return ImmutableList.of((ASTNode) this);
+  }
+
+  @Override
+  public String getText() {
+    return _contents;
+  }
+}

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/core-creole.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/creole/core-creole.json
@@ -294,7 +294,7 @@
   {
     "name":   "Inline syntax highlighting",
     "input":  "Look at this [<java>]System.out.println(\"code!\");[</java>]",
-    "output": "<p>Look at this <code class='wiki-content inline'>System.out.println(&quot;code!&quot;);</code></p>"
+    "output": "<p>Look at this <code class='wiki-content inline java'>System.out.println(&quot;code!&quot;);</code></p>"
   },
   {
     "name":   "Block syntax highlighting",

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
@@ -50,6 +50,21 @@
     "output": "<p>Some text <code class='wiki-content inline'>System.out.print(&quot;Hello, &quot;);</code>end text</p>"
   },
   {
+    "name":   "Inline syntax highlighting at beginning of line with no other content",
+    "input":  "`System.out.print(\"Hello, \");`",
+    "output": "<p><code class='wiki-content inline'>System.out.print(&quot;Hello, &quot;);</code></p>"
+  },
+  {
+    "name":   "Inline syntax highlighting empty",
+    "input":  "``",
+    "output": ""
+  },
+  {
+    "name":   "Inline syntax highlighting single followed by newline",
+    "input":  "`\n",
+    "output": ""
+  },
+  {
     "name":   "Image link vs no wiki",
     "input":  "Hello {{{//there//}}}.",
     "output": "<p>Hello <code>//there//</code>.</p>"

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
@@ -30,6 +30,31 @@
     "output": "<pre><code class='java'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n</code></pre>"
   },
   {
+    "name":   "Block syntax highlighting java hint, no final newline",
+    "input":  "```java\nSystem.out.print(\"Hello, \");\nSystem.out.println(\"world!\");```",
+    "output": "<pre><code class='java'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);</code></pre>"
+  },
+  {
+    "name":   "Block syntax highlighting java hint terminated by EOF",
+    "input":  "```java\nSystem.out.print(\"Hello, \");\nSystem.out.println(\"world!\");\n",
+    "output": "<pre><code class='java'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);</code></pre>"
+  },
+  {
+    "name":   "Block syntax highlighting inline",
+    "input":  "```java System.out.print(\"Hello, \");```",
+    "output": "<pre><code>java System.out.print(&quot;Hello, &quot;);</code></pre>"
+  },
+  {
+    "name":   "Block syntax highlighting inline one word",
+    "input":  "```java```",
+    "output": "<pre><code>java</code></pre>"
+  },
+  {
+    "name":   "Block syntax highlighting inline one word, inline",
+    "input":  "foo ```java``` bar",
+    "output": "<p>foo</p><pre><code>java</code></pre><p>bar</p>"
+  },
+  {
     "name":   "Block syntax highlighting java trailing space",
     "input":  "```java  \nSystem.out.print(\"Hello, \");\nSystem.out.println(\"world!\");\n```",
     "output": "<pre><code class='java'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n</code></pre>"
@@ -53,6 +78,11 @@
     "name":   "Block syntax highlighting incomplete",
     "input":  "```java System.out.print(\"Hello, \");\n```\nbar\n```",
     "output": "<p>```java System.out.print(&quot;Hello, &quot;);</p><pre><code>bar\n</code></pre>"
+  },
+  {
+    "name":   "Block syntax highlighting no body before EOF",
+    "input":  "```java",
+    "output": "<p>```java</p>"
   },
   {
     "name":   "Inline syntax highlighting",

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
@@ -65,6 +65,11 @@
     "output": "<pre><code class='java'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n</code></pre>"
   },
   {
+    "name":   "Block syntax highlighting java not at start of line",
+    "input":  "some other text ```java  \nSystem.out.print(\"Hello, \");\nSystem.out.println(\"world!\");\n```",
+    "output": "<p>some other text ```java  \nSystem.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n```</p>"
+  },
+  {
     "name":   "Block syntax highlighting default, invalid hint",
     "input":  "```notalang\nSystem.out.print(\"Hello, \");\nSystem.out.println(\"world!\");\n```",
     "output": "<pre><code class='notalang'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n</code></pre>"

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/rendering-extensions.json
@@ -30,6 +30,16 @@
     "output": "<pre><code class='java'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n</code></pre>"
   },
   {
+    "name":   "Block syntax highlighting java trailing space",
+    "input":  "```java  \nSystem.out.print(\"Hello, \");\nSystem.out.println(\"world!\");\n```",
+    "output": "<pre><code class='java'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n</code></pre>"
+  },
+  {
+    "name":   "Block syntax highlighting java leading space",
+    "input":  " ```java  \nSystem.out.print(\"Hello, \");\nSystem.out.println(\"world!\");\n```",
+    "output": "<pre><code class='java'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n</code></pre>"
+  },
+  {
     "name":   "Block syntax highlighting default, invalid hint",
     "input":  "```notalang\nSystem.out.print(\"Hello, \");\nSystem.out.println(\"world!\");\n```",
     "output": "<pre><code class='notalang'>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n</code></pre>"
@@ -38,6 +48,11 @@
     "name":   "Block syntax highlighting default Java, none specified ",
     "input":  "```\nSystem.out.print(\"Hello, \");\nSystem.out.println(\"world!\");\n```",
     "output": "<pre><code>System.out.print(&quot;Hello, &quot;);\nSystem.out.println(&quot;world!&quot;);\n</code></pre>"
+  },
+  {
+    "name":   "Block syntax highlighting incomplete",
+    "input":  "```java System.out.print(\"Hello, \");\n```\nbar\n```",
+    "output": "<p>```java System.out.print(&quot;Hello, &quot;);</p><pre><code>bar\n</code></pre>"
   },
   {
     "name":   "Inline syntax highlighting",


### PR DESCRIPTION
Fixes to the rendering of backtick code blocks to make it more like markdown.
(In the following examples <backticks> is used to represent three backticks, this is a markdown rendered comment box).
    
The start of a code block must be of the form (modulo whitespace)
```
 <backticks> <lanugage hint>?
 <code>
 <backticks>
```
 and must appear at the start of a line (unless it occurs at the
 beginning of a table cell).
   
 Code block declarations that are not matched by the grammar are rendered
 verbatim to help the user find errors in their markup.
    
 So for example:
 i) ` <backticks>java some other text`
 ii) `some other text <backticks>java and other`
 both are rendered verbatim
    
 The beginning of a code block is immediately followed by an EOF (so it
 has no body) then it is also rendered verbatim.

Inline codeblocks can also be declared:
`some text <backticks>code<backticks> other text`

https://jira.int.corefiling.com/browse/REVIKI-587
