### PR TITLE
REVIKI-587 - Improved code highlighting

### DIFF
--- a/WebContent/WEB-INF/templates/EditPage.jsp
+++ b/WebContent/WEB-INF/templates/EditPage.jsp
@@ -129,7 +129,7 @@
       </script>
     </c:if>
     <div class="row">
-      <div class="col-sm-6 col-sm-offset-1">
+      <div class="col-sm-10 col-sm-offset-1">
         <jsp:include page="cheatsheet.html"></jsp:include>
       </div><!--col-->
     </div><!--row-->

--- a/WebContent/WEB-INF/templates/cheatsheet.html
+++ b/WebContent/WEB-INF/templates/cheatsheet.html
@@ -1,22 +1,37 @@
 <div id="MarkupHelp">
-<h3>Cheatsheet</h3>
-<table>
-  <tbody>
-  <tr><td>//italics//</td><td class="arrow">&#8594;</td><td><em>italics</em></td></tr>
-  <tr><td>**bold**</td><td class="arrow">&#8594;</td><td><strong>bold</strong></td></tr>
-  <tr><td>--strikethrough--</td><td class="arrow">&#8594;</td><td><del>strikethrough</del></td></tr>
-  <tr><td>* Bullet list<br/>* Second item<br/>** Sub item</td><td class="arrow">&#8594;</td><td>&#8226; Bullet list<br/>&#8226; Second item<br/>..&#8226; Sub item</td></tr>
-  <tr><td># Numbered list<br/># Second item<br/>## Sub item</td><td class="arrow">&#8594;</td><td>1. Numbered list<br/>2. Second item<br/>2.1 Sub item</td></tr>
-  <tr><td>WikiPage, c2:WikiPage</td><td class="arrow">&#8594;</td><td>Internal, inter-wiki links</td></tr>
-  <tr><td>[[AnyLink|named link]]</td><td class="arrow">&#8594;</td><td><a href="">named link</a></td></tr>
-  <tr><td>== Large heading<br/>=== Medium heading<br/>==== Small heading</td><td class="arrow">&#8594;</td><td><span style="font-size: 130%; font-weight: bold;"> Large heading</span><br/><span style="font-size: 115%; font-weight: bold;">Medium heading</span><br/><span style="font-size: 100%; font-weight: bold;">Small heading</span></td></tr>
-  <tr><td>No<br/> linebreak!<br/><br/>Use empty line</td><td class="arrow">&#8594;</td><td>No line break!<br/><br/>Use empty line</td></tr>
-  <tr><td>Forced\\linebreak<br/></td><td class="arrow">&#8594;</td><td>Forced<br/>line break</td></tr>  
-  <tr><td>Horizontal line:<br/>----</td><td class="arrow">&#8594;</td><td>Horizontal line: <hr/></td></tr>
-  <tr><td>{{Image.jpg|title}}</td><td class="arrow">&#8594;</td><td>Image with title</td></tr>
-  <tr><td>|=|=table|=header|<br/>|a|table|row|<br/>|b|table|row|</td><td class="arrow">&#8594;</td><td>Table</td></tr>
-  <tr><td>{{{<br/>== [[Nowiki]]:<br/> //**don't** format//<br/>}}}</td><td class="arrow">&#8594;</td><td>== [[Nowiki]]:<br/> //**don't** format//</td></tr>
-  <tr><td>[&lt;html&gt;]<br/>&lt;div&gt;Some HTML&lt;/div&gt;<br/>[&lt;/html&gt;]</td><td class="arrow">&#8594;</td><td><div>Some HTML</div></td></tr>
-</tbody>
-</table>
-</div>
+  <h3>Cheatsheet</h3>
+  <div class="markup_table">
+    <div class="column1">
+      <table>
+        <tbody>
+        <tr><td>//italics//</td><td class="arrow">&#8594;</td><td><em>italics</em></td></tr>
+        <tr><td>**bold**</td><td class="arrow">&#8594;</td><td><strong>bold</strong></td></tr>
+        <tr><td>--strikethrough--</td><td class="arrow">&#8594;</td><td><del>strikethrough</del></td></tr>
+        <tr><td>* Bullet list<br/>* Second item<br/>** Sub item</td><td class="arrow">&#8594;</td><td>&#8226; Bullet list<br/>&#8226; Second item<br/>..&#8226; Sub item</td></tr>
+        <tr><td># Numbered list<br/># Second item<br/>## Sub item</td><td class="arrow">&#8594;</td><td>1. Numbered list<br/>2. Second item<br/>2.1 Sub item</td></tr>
+        <tr><td>WikiPage, c2:WikiPage</td><td class="arrow">&#8594;</td><td>Internal, inter-wiki links</td></tr>
+        <tr><td>[[AnyLink|named link]]</td><td class="arrow">&#8594;</td><td><a href="">named link</a></td></tr>
+        <tr><td>== Large heading<br/>=== Medium heading<br/>==== Small heading</td><td class="arrow">&#8594;</td><td><span style="font-size: 130%; font-weight: bold;"> Large heading</span><br/><span style="font-size: 115%; font-weight: bold;">Medium heading</span><br/><span style="font-size: 100%; font-weight: bold;">Small heading</span></td></tr>
+        <tr><td>No<br/> linebreak!<br/><br/>Use empty line</td><td class="arrow">&#8594;</td><td>No line break!<br/><br/>Use empty line</td></tr>
+        <tr><td>Forced\\linebreak<br/></td><td class="arrow">&#8594;</td><td>Forced<br/>line break</td></tr>  
+        <tr><td>{{Image.jpg|title}}</td><td class="arrow">&#8594;</td><td>Image with title</td></tr>
+        </tbody>
+      </table>
+    </div><!--column1-->
+    <div class="column2">
+      <table>
+        <tbody>
+        <tr><td>Horizontal line:<br/>----</td><td class="arrow">&#8594;</td><td>Horizontal line: <hr/></td></tr>
+        <tr><td>|=|=table|=header|<br/>|a|table|row|<br/>|b|table|row|</td><td class="arrow">&#8594;</td><td>Table</td></tr>
+        <tr><td>{{{<br/>== [[Nowiki]]:<br/> //**don't** format//<br/>}}}</td><td class="arrow">&#8594;</td><td><pre>== [[Nowiki]]:<br/> //**don't** format//</pre></td></tr>
+        <tr><td>```java<br/>void aMethod {<br/>// some java code<br/>}<br/>```</td><td class="arrow">&#8594;</td><td><pre><code>void aMethod() {
+// some java code
+}</code></pre></td></tr>
+        <tr><td>Some `inline(1)` code</td><td class="arrow">&#8594;</td><td>Some<code class="inline">inline(1)</code>code</td></tr>
+        <tr><td>"""<br/>blockquote<br/>"""</td><td class="arrow">&#8594;</td><td><blockquote>blockquote</blockquote></td></tr>
+        <tr><td>[&lt;html&gt;]<br/>&lt;div&gt;Some HTML&lt;/div&gt;<br/>[&lt;/html&gt;]</td><td class="arrow">&#8594;</td><td><div>Some HTML</div></td></tr>
+        </tbody>
+      </table>
+    </div><!--column2-->
+  </div><!--markup_table-->
+</div><!--MarkupHelp-->

--- a/WebContent/resources/default-style.css
+++ b/WebContent/resources/default-style.css
@@ -168,8 +168,9 @@ div#MarkupHelp table {
   margin-bottom: 0; border-top: 3px solid #999; border-left: 3px solid #999;
   border-right: 3px solid #BBB; border-bottom: 3px solid #BBB
 }
+
 div#MarkupHelp td {
-  font-size: 80%; padding: 0.2em; margin: 0; border: 1px solid #999; border-width: 1px 0 1px 0;
+  font-size: 80%; padding: 0.3em; margin: 0; border: 1px solid #999; border-width: 1px 0 1px 0;
   vertical-align: top; white-space: nowrap;
 }
 div#MarkupHelp td.arrow {
@@ -189,6 +190,8 @@ div#MarkupHelp p {
 #MarkupHelp table {
   border-spacing: 0;
   border-collapse: separate;
+  float: left;
+  margin-right: 15px;
 }
 
 @media print {


### PR DESCRIPTION
Add new syntax (code and blockquote) to the cheatsheet.

* Expand the cheatsheet to two columns.
* Make the nowiki example a preformat block.

https://jira.int.corefiling.com/browse/REVIKI-587