### PR TITLE
REVIKI-642 Avoid unnecessary creole rendering

### DIFF
--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/RawRenderer.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/RawRenderer.java
@@ -7,8 +7,8 @@ import java.io.UnsupportedEncodingException;
 import net.hillsdon.reviki.vc.PageInfo;
 import net.hillsdon.reviki.web.urls.URLOutputFilter;
 import net.hillsdon.reviki.wiki.MarkupRenderer;
-import net.hillsdon.reviki.wiki.renderer.creole.CreoleRenderer;
 import net.hillsdon.reviki.wiki.renderer.creole.ast.ASTNode;
+import net.hillsdon.reviki.wiki.renderer.creole.ast.Raw;
 
 /**
  * A basic renderer which just turns its input into a stream. This exploits the
@@ -23,7 +23,7 @@ public class RawRenderer extends MarkupRenderer<InputStream> {
   @Override
   public ASTNode parse(final PageInfo page) {
     _page = page;
-    return CreoleRenderer.render(page, null, null);
+    return new Raw(page.getContent());
   }
 
   @Override

--- a/webtests/net/hillsdon/reviki/webtests/TestAttachments.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestAttachments.java
@@ -16,6 +16,7 @@
 package net.hillsdon.reviki.webtests;
 
 import static net.hillsdon.reviki.web.pages.impl.DefaultPageImpl.ERROR_NO_FILE;
+import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.PAGE_HEADER;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -26,9 +27,11 @@ import java.util.Map;
 
 import net.hillsdon.reviki.vc.AttachmentHistory;
 import net.hillsdon.reviki.vc.ChangeInfo;
+import net.hillsdon.reviki.vc.PageReference;
 import net.hillsdon.reviki.vc.StoreKind;
 
 import org.apache.commons.io.IOUtils;
+
 import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.UnexpectedPage;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
@@ -186,6 +189,23 @@ public class TestAttachments extends WebTestSupport {
     // Previous version should still be available
     List<HtmlDeletedText> previousRevisions = (List<HtmlDeletedText>) attachments.getByXPath("//span[substring(text(), 1, 8)='file.txt']");
     assertEquals(1, previousRevisions.size());
+  }
+  
+  public void testAttachmentsPageContainsHeader() throws Exception {
+    // https://jira.int.corefiling.com/browse/REVIKI-642
+    // Check that the header page was added for the attachements page
+    final PageReference headerPage = PAGE_HEADER;
+    final String expect = "T" + System.currentTimeMillis() + headerPage.getPath().toLowerCase();
+    editWikiPage(headerPage.getPath(), expect, "", "Some new content", null);
+    try {
+      String name = uniqueWikiPageName("AttachmentPageHeaderTest");
+      HtmlPage edited = editWikiPage(name, "some content", "", "", true);
+      HtmlPage attachmentsPage = clickAttachmentsLink(edited, name);
+      assertTrue(attachmentsPage.asText().contains(expect));
+    }
+    finally {
+      editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
+    }
   }
 
   public void testUploadAttachmentWithDefaultMessage() throws Exception {

--- a/webtests/net/hillsdon/reviki/webtests/TestAttachments.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestAttachments.java
@@ -61,7 +61,7 @@ public class TestAttachments extends WebTestSupport {
     TextPage attachment = (TextPage) link.click();
     return attachment.getContent().trim();
   }
-  
+
   public void testGetAttachmentWithNoResults() {
     final Map<String, AttachmentHistory> results = new LinkedHashMap<String, AttachmentHistory>();
     ChangeInfo ci = new ChangeInfo("k", "k", "k", new java.util.Date(), 10000, "ro", StoreKind.ATTACHMENT, null, null, 1221221);
@@ -158,7 +158,7 @@ public class TestAttachments extends WebTestSupport {
     HtmlAnchor previousRevision = (HtmlAnchor) attachments.getByXPath("//a[contains(@href, '?revision')]").get(0);
     assertEquals("File 1.", getTextAttachmentAtEndOfLink(previousRevision));
   }
-  
+
   @SuppressWarnings("unchecked")
   public void testUploadRenameAndDeleteAttachment() throws Exception {
     // https://bugs.corefiling.com/show_bug.cgi?id=13574
@@ -190,7 +190,7 @@ public class TestAttachments extends WebTestSupport {
     List<HtmlDeletedText> previousRevisions = (List<HtmlDeletedText>) attachments.getByXPath("//span[substring(text(), 1, 8)='file.txt']");
     assertEquals(1, previousRevisions.size());
   }
-  
+
   public void testAttachmentsPageContainsHeader() throws Exception {
     // https://jira.int.corefiling.com/browse/REVIKI-642
     // Check that the header page was added for the attachements page

--- a/webtests/net/hillsdon/reviki/webtests/TestEditing.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestEditing.java
@@ -82,7 +82,7 @@ public class TestEditing extends WebTestSupport {
     assertTrue(edited.asText().contains("Initial Status:"));
     assertFalse(edited.asText().contains("Initial Status: completed"));
   }
-  
+
   public void testEditPageContainsHeader() throws Exception {
     // https://jira.int.corefiling.com/browse/REVIKI-642
     // Check that the header page was added for the edit page
@@ -99,7 +99,7 @@ public class TestEditing extends WebTestSupport {
       editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
     }
   }
-  
+
   public void testPreviewDiffBug() throws Exception {
     // https://bugs.corefiling.com/show_bug.cgi?id=13510
     // Old versions of the diff_match_patch package have a bug in the diff_cleanupSemantic method
@@ -107,19 +107,19 @@ public class TestEditing extends WebTestSupport {
     String name = uniqueWikiPageName("PreviewPageTest");
     String content = "=" + NEWLINE_TEXTAREA + "This is a lis of things that someone be doing if" + NEWLINE_TEXTAREA + "===Wiki" + NEWLINE_TEXTAREA;
     String newContent = "||" + NEWLINE_TEXTAREA + "==";
-    
+
     HtmlPage edited = editWikiPage(name, content, "", "", true);
     HtmlPage editPage = clickEditLink(edited);
     HtmlForm form = editPage.getFormByName(ID_EDIT_FORM);
     HtmlTextArea contentArea = form.getTextAreaByName("content");
     contentArea.setText(newContent);
     editPage = (HtmlPage) form.getButtonByName("preview").click();
-    
+
     form = editPage.getFormByName(ID_EDIT_FORM);
     contentArea = form.getTextAreaByName("content");
     assertEquals(newContent + NEWLINE_TEXTAREA, contentArea.getText());
   }
-  
+
   public void testPreview() throws Exception {
     String name = uniqueWikiPageName("PreviewPageTest");
     HtmlPage editPage = clickEditLink(getWikiPage(name));

--- a/webtests/net/hillsdon/reviki/webtests/TestEditing.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestEditing.java
@@ -18,6 +18,8 @@ package net.hillsdon.reviki.webtests;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 
+import net.hillsdon.reviki.vc.PageReference;
+
 import org.jaxen.JaxenException;
 
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
@@ -27,6 +29,8 @@ import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
 import com.gargoylesoftware.htmlunit.html.HtmlTextArea;
+
+import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.PAGE_HEADER;
 
 public class TestEditing extends WebTestSupport {
 
@@ -77,6 +81,23 @@ public class TestEditing extends WebTestSupport {
     edited = editWikiPage(name, "Initial Status: <<attr:status>>", "", "", false);
     assertTrue(edited.asText().contains("Initial Status:"));
     assertFalse(edited.asText().contains("Initial Status: completed"));
+  }
+  
+  public void testEditPageContainsHeader() throws Exception {
+    // https://jira.int.corefiling.com/browse/REVIKI-642
+    // Check that the header page was added for the edit page
+    final PageReference headerPage = PAGE_HEADER;
+    final String expect = "T" + System.currentTimeMillis() + headerPage.getPath().toLowerCase();
+    editWikiPage(headerPage.getPath(), expect, "", "Some new content", null);
+    try {
+      String name = uniqueWikiPageName("EditPageHeaderTest");
+      HtmlPage edited = editWikiPage(name, "some content", "", "", true);
+      HtmlPage editPage = clickEditLink(edited);
+      assertTrue(editPage.asText().contains(expect));
+    }
+    finally {
+      editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
+    }
   }
   
   public void testPreviewDiffBug() throws Exception {

--- a/webtests/net/hillsdon/reviki/webtests/TestHistory.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestHistory.java
@@ -67,7 +67,7 @@ public class TestHistory extends WebTestSupport {
     assertEquals(1, divs.size());
 
   }
-  
+
   public void testHistoryPageContainsHeader() throws Exception {
     // https://jira.int.corefiling.com/browse/REVIKI-642
     // Check that the header page was added for the history page
@@ -84,7 +84,7 @@ public class TestHistory extends WebTestSupport {
       editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
     }
   }
-  
+
   public void testAtom() throws Exception {
     // https://bugs.corefiling.com/show_bug.cgi?id=44456
     String pageName = uniqueWikiPageName("HistoryAtomTest");

--- a/webtests/net/hillsdon/reviki/webtests/TestHistory.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestHistory.java
@@ -15,7 +15,11 @@
  */
 package net.hillsdon.reviki.webtests;
 
+import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.PAGE_HEADER;
+
 import java.util.List;
+
+import net.hillsdon.reviki.vc.PageReference;
 
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import com.gargoylesoftware.htmlunit.html.DomText;
@@ -36,7 +40,7 @@ public class TestHistory extends WebTestSupport {
     String pageName = uniqueWikiPageName("HistoryTest");
     HtmlPage page = editWikiPage(pageName, "Initial content", "", "", true);
     page = editWikiPage(pageName, "Altered content", "", "s/Initial/Altered", false);
-    HtmlPage history = (HtmlPage) ((HtmlAnchor) page.getByXPath("//a[@name='history']").iterator().next()).click();
+    HtmlPage history = clickHistoryLink(page);
     List<HtmlTableRow> historyRows = (List<HtmlTableRow>) history.getByXPath("//tr[td]");
     assertEquals(3, historyRows.size());
     HtmlTableRow altered = historyRows.get(1);
@@ -62,6 +66,23 @@ public class TestHistory extends WebTestSupport {
     divs = (List<HtmlDivision>) diff.getByXPath("//div[@id='flash']/.");
     assertEquals(1, divs.size());
 
+  }
+  
+  public void testHistoryPageContainsHeader() throws Exception {
+    // https://jira.int.corefiling.com/browse/REVIKI-642
+    // Check that the header page was added for the history page
+    final PageReference headerPage = PAGE_HEADER;
+    final String expect = "T" + System.currentTimeMillis() + headerPage.getPath().toLowerCase();
+    editWikiPage(headerPage.getPath(), expect, "", "Some new content", null);
+    try {
+      String name = uniqueWikiPageName("EditPageHeaderTest");
+      HtmlPage edited = editWikiPage(name, "some content", "", "", true);
+      HtmlPage historyPage = clickHistoryLink(edited);
+      assertTrue(historyPage.asText().contains(expect));
+    }
+    finally {
+      editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
+    }
   }
   
   public void testAtom() throws Exception {

--- a/webtests/net/hillsdon/reviki/webtests/TestRename.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestRename.java
@@ -15,9 +15,12 @@
  */
 package net.hillsdon.reviki.webtests;
 
+import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.PAGE_HEADER;
 import static net.hillsdon.reviki.webtests.TestAttachments.getTextAttachmentAtEndOfLink;
 
 import java.util.List;
+
+import net.hillsdon.reviki.vc.PageReference;
 
 import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.SVNNodeKind;
@@ -92,6 +95,23 @@ public class TestRename extends AddWikiWebTestSupport {
     // If fromPage is subsequently edited then we no longer show the notification
     fromPage = editWikiPage(fromPageName, "another edit", "", "Whatever", false);
     assertFalse(fromPage.asText().contains(toPageName));
+  }
+  
+  public void testRenamePageContainsHeader() throws Exception {
+    // https://jira.int.corefiling.com/browse/REVIKI-642
+    // Check that the header page was added for the rename page
+    final PageReference headerPage = PAGE_HEADER;
+    final String expect = "T" + System.currentTimeMillis() + headerPage.getPath().toLowerCase();
+    editWikiPage(headerPage.getPath(), expect, "", "Some new content", null);
+    try {
+      String name = uniqueWikiPageName("RenamePageHeaderTest");
+      HtmlPage edited = editWikiPage(name, "some content", "", "", true);
+      HtmlPage renamePage = (HtmlPage) edited.getAnchorByName("rename").click();
+      assertTrue(renamePage.asText().contains(expect));
+    }
+    finally {
+      editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
+    }
   }
 
   private static final String DIRECTORY2 = "doesNotExist2";

--- a/webtests/net/hillsdon/reviki/webtests/TestRename.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestRename.java
@@ -66,14 +66,14 @@ public class TestRename extends AddWikiWebTestSupport {
     assertSearchDoesNotFindPage(page, fromPageName);
     editWikiPage(fromPageName, "This checks old page is new.", "", "Whatever", true);
   }
-  
+
   @SuppressWarnings("unchecked")
   public void testRenameCommitMessage() throws Exception {
     String fromPageName = uniqueWikiPageName("RenameTestFrom");
     String toPageName = uniqueWikiPageName("RenameTestTo");
     HtmlPage page = editWikiPage(fromPageName, "Catchy tunes", "", "Whatever", true);
     page = renamePage(fromPageName, toPageName);
-    
+
     HtmlPage history = (HtmlPage) ((HtmlAnchor) page.getByXPath("//a[@name='history']").iterator().next()).click();
     List<HtmlTableRow> historyRows = (List<HtmlTableRow>) history.getByXPath("//tr[td]");
     assertEquals(3, historyRows.size());
@@ -86,17 +86,17 @@ public class TestRename extends AddWikiWebTestSupport {
     String fromPageName = uniqueWikiPageName("RenameTestFrom");
     String toPageName = uniqueWikiPageName("RenameTestTo");
     editWikiPage(fromPageName, "Catchy tunes", "", "Whatever", true);
-    
+
     renamePage(fromPageName, toPageName);
     HtmlPage fromPage = getWikiPage(fromPageName);
-    
+
     assertTrue(fromPage.asText().contains(toPageName));
-    
+
     // If fromPage is subsequently edited then we no longer show the notification
     fromPage = editWikiPage(fromPageName, "another edit", "", "Whatever", false);
     assertFalse(fromPage.asText().contains(toPageName));
   }
-  
+
   public void testRenamePageContainsHeader() throws Exception {
     // https://jira.int.corefiling.com/browse/REVIKI-642
     // Check that the header page was added for the rename page
@@ -124,7 +124,7 @@ public class TestRename extends AddWikiWebTestSupport {
       removeDir(repository.getCommitEditor("Removing test directory", null), DIRECTORY2);
     }
   }
-  
+
   protected void createOurDirectory2(final ISVNEditor editor) {
     try {
       editor.openRoot(-1);
@@ -149,13 +149,13 @@ public class TestRename extends AddWikiWebTestSupport {
     final String wikiName2 = "uniqueWiki" + uniqueName();
     createOurDirectory2(_repository.getCommitEditor("Creating test directory", null));
     addWiki(wikiName2, DIRECTORY2);
-    
+
     String fromPageName = uniqueWikiPageName("RenameTestFrom");
     editWikiPage(getWebPage("pages/" + wikiName1 + "/" + fromPageName), "Catchy tunes", "", "Whatever", null);
-    
+
     // Now move the wiki page
     String toPageName = uniqueWikiPageName("RenameTestTo");
-    ISVNEditor editor = _repository.getCommitEditor("Move wiki page", null);    
+    ISVNEditor editor = _repository.getCommitEditor("Move wiki page", null);
     try {
       editor.openRoot(-1);
       editor.openDir(DIRECTORY2, -1);
@@ -172,7 +172,7 @@ public class TestRename extends AddWikiWebTestSupport {
     HtmlPage fromPage = getWebPage("pages/" + wikiName1 + "/" + fromPageName);
     HtmlPage toPage = getWebPage("pages/" + wikiName2 + "/" + toPageName);
     assertTrue(toPage.asText(), toPage.asText().contains("Catchy tunes")); // Check we really did move the page
-    
+
     assertTrue(fromPage.asText(), fromPage.asText().contains("Page has been moved outside of this wiki"));
     assertTrue(fromPage.asText(), fromPage.asText().contains(toPageName));
   }

--- a/webtests/net/hillsdon/reviki/webtests/WebTestSupport.java
+++ b/webtests/net/hillsdon/reviki/webtests/WebTestSupport.java
@@ -292,5 +292,9 @@ public abstract class WebTestSupport extends TestCase {
   protected HtmlPage getWikiList() throws IOException {
     return getWebPage("list");
   }
+  
+  protected HtmlPage clickHistoryLink(final HtmlPage page) throws IOException {
+    return (HtmlPage) ((HtmlAnchor) page.getByXPath("//a[@name='history']").iterator().next()).click();
+  }
 
 }

--- a/webtests/net/hillsdon/reviki/webtests/WebTestSupport.java
+++ b/webtests/net/hillsdon/reviki/webtests/WebTestSupport.java
@@ -136,7 +136,7 @@ public abstract class WebTestSupport extends TestCase {
   protected HtmlPage getWebPage(final String path) throws IOException {
     return (HtmlPage) _client.getPage(getUrl(path));
   }
-  
+
   protected XmlPage getXmlPage(final String path) throws IOException {
     return (XmlPage) _client.getPage(getUrl(path));
   }
@@ -149,7 +149,7 @@ public abstract class WebTestSupport extends TestCase {
   protected HtmlPage getWikiPage(final String name) throws IOException {
     return getWebPage("pages/test/" + URIUtil.encodeWithinPath(name));
   }
-  
+
   protected XmlPage getHistoryAtomFeed(final String name) throws IOException {
     return getXmlPage("pages/test/" + URIUtil.encodeWithinPath(name) + "?history&ctype=atom");
   }
@@ -292,7 +292,7 @@ public abstract class WebTestSupport extends TestCase {
   protected HtmlPage getWikiList() throws IOException {
     return getWebPage("list");
   }
-  
+
   protected HtmlPage clickHistoryLink(final HtmlPage page) throws IOException {
     return (HtmlPage) ((HtmlAnchor) page.getByXPath("//a[@name='history']").iterator().next()).click();
   }

--- a/wiki-src/net/hillsdon/reviki/web/dispatching/impl/WikiHandlerImpl.java
+++ b/wiki-src/net/hillsdon/reviki/web/dispatching/impl/WikiHandlerImpl.java
@@ -15,19 +15,13 @@
  */
 package net.hillsdon.reviki.web.dispatching.impl;
 
-import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.COMPLIMENTARY_CONTENT_PAGES;
-
-import java.io.IOException;
 import java.util.Collections;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import net.hillsdon.reviki.vc.ChangeNotificationDispatcher;
-import net.hillsdon.reviki.vc.VersionedPageInfo;
-import net.hillsdon.reviki.vc.PageReference;
 import net.hillsdon.reviki.vc.PageStoreAuthenticationException;
-import net.hillsdon.reviki.vc.PageStoreException;
 import net.hillsdon.reviki.vc.PageStoreInvalidException;
 import net.hillsdon.reviki.vc.impl.CachingPageStore;
 import net.hillsdon.reviki.web.common.ConsumedPath;
@@ -40,11 +34,8 @@ import net.hillsdon.reviki.web.handlers.PageHandler;
 import net.hillsdon.reviki.web.urls.Configuration;
 import net.hillsdon.reviki.web.urls.InternalLinker;
 import net.hillsdon.reviki.web.urls.WikiUrls;
-import net.hillsdon.reviki.web.urls.impl.ResponseSessionURLOutputFilter;
 import net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences;
 import net.hillsdon.reviki.web.vcintegration.RequestLifecycleAwareManager;
-import net.hillsdon.reviki.wiki.MarkupRenderer;
-import net.hillsdon.reviki.wiki.renderer.SvnWikiRenderer;
 import net.hillsdon.reviki.wiki.renderer.creole.LinkResolutionContext;
 
 /**
@@ -68,7 +59,6 @@ public class WikiHandlerImpl implements WikiHandler {
   public static final String ATTRIBUTE_WIKI_IS_VALID = "wikiIsValid";
 
   private final RequestLifecycleAwareManager _requestLifecycleAwareManager;
-  private final MarkupRenderer<String> _renderer;
   private final CachingPageStore _cachingPageStore;
   private final InternalLinker _internalLinker;
   private final ChangeNotificationDispatcher _syncUpdater;
@@ -78,9 +68,8 @@ public class WikiHandlerImpl implements WikiHandler {
 
   private final Configuration _configuration;
 
-  public WikiHandlerImpl(CachingPageStore cachingPageStore, SvnWikiRenderer renderer, InternalLinker internalLinker, ChangeNotificationDispatcher syncUpdater, RequestLifecycleAwareManager requestLifecycleAwareManager, ResourceHandler resources, PageHandler handler, WikiUrls wikiUrls, Configuration configuration) {
+  public WikiHandlerImpl(CachingPageStore cachingPageStore, InternalLinker internalLinker, ChangeNotificationDispatcher syncUpdater, RequestLifecycleAwareManager requestLifecycleAwareManager, ResourceHandler resources, PageHandler handler, WikiUrls wikiUrls, Configuration configuration) {
     _cachingPageStore = cachingPageStore;
-    _renderer = renderer;
     _internalLinker = internalLinker;
     _syncUpdater = syncUpdater;
     _requestLifecycleAwareManager = requestLifecycleAwareManager;
@@ -104,19 +93,18 @@ public class WikiHandlerImpl implements WikiHandler {
       public View handle(ConsumedPath path, HttpServletRequest request, HttpServletResponse response) throws Exception {
         request.setAttribute(WikiUrls.KEY, _wikiUrls);
         request.setAttribute(JspView.ATTR_CSS_URL, _internalLinker.uri(BuiltInPageReferences.CONFIG_CSS.getPath(), "ctype=raw").toASCIIString());
-        
+
         // Used for resolving links in the context of this request
         request.setAttribute("internalLinker", _internalLinker);
         request.setAttribute("configuration", _configuration);
         request.setAttribute("pageStore", _cachingPageStore);
         request.setAttribute("linkResolutionContext", new LinkResolutionContext(_internalLinker, _configuration.getInterWikiLinker(), _configuration, _cachingPageStore));
-        
+
         if ("resources".equals(path.peek())) {
           return _resources.handle(path.consume(), request, response);
         }
 
         _syncUpdater.sync();
-        addSideBarEtcToRequest(request, response);
         return _pageHandler.handle(path, request, response);
       }
     });
@@ -142,13 +130,4 @@ public class WikiHandlerImpl implements WikiHandler {
       }
     }
   }
-
-  private void addSideBarEtcToRequest(final HttpServletRequest request, final HttpServletResponse response) throws PageStoreException, IOException {
-    for (PageReference ref : COMPLIMENTARY_CONTENT_PAGES) {
-      final String requestVarName = "rendered" + ref.getPath().substring("Config".length());
-      VersionedPageInfo page = _cachingPageStore.get(ref, -1);
-      request.setAttribute(requestVarName, _renderer.render(page, new ResponseSessionURLOutputFilter(request, response)).get());
-    }
-  }
-
 }

--- a/wiki-src/net/hillsdon/reviki/web/handlers/impl/PageHandlerImpl.java
+++ b/wiki-src/net/hillsdon/reviki/web/handlers/impl/PageHandlerImpl.java
@@ -137,7 +137,7 @@ public class PageHandlerImpl implements PageHandler {
           addSideBarEtcToRequest(request, response);
         }
         return page.get(pageReference, path, request, response);
-      }     
+      }
     }
   }
 

--- a/wiki-src/net/hillsdon/reviki/web/handlers/impl/PageHandlerImpl.java
+++ b/wiki-src/net/hillsdon/reviki/web/handlers/impl/PageHandlerImpl.java
@@ -19,24 +19,34 @@ import static net.hillsdon.reviki.web.pages.impl.DefaultPageImpl.SUBMIT_COPY;
 import static net.hillsdon.reviki.web.pages.impl.DefaultPageImpl.SUBMIT_RENAME;
 import static net.hillsdon.reviki.web.pages.impl.DefaultPageImpl.SUBMIT_SAVE;
 import static net.hillsdon.reviki.web.pages.impl.DefaultPageImpl.SUBMIT_UNLOCK;
+import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.COMPLIMENTARY_CONTENT_PAGES;
 import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.PAGE_FRONT_PAGE;
+
+import java.io.IOException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import net.hillsdon.reviki.vc.NotFoundException;
 import net.hillsdon.reviki.vc.PageReference;
+import net.hillsdon.reviki.vc.PageStoreException;
+import net.hillsdon.reviki.vc.VersionedPageInfo;
+import net.hillsdon.reviki.vc.impl.CachingPageStore;
 import net.hillsdon.reviki.vc.impl.PageReferenceImpl;
 import net.hillsdon.reviki.web.common.ConsumedPath;
 import net.hillsdon.reviki.web.common.InvalidInputException;
 import net.hillsdon.reviki.web.common.JspView;
 import net.hillsdon.reviki.web.common.View;
+import net.hillsdon.reviki.web.common.ViewTypeConstants;
 import net.hillsdon.reviki.web.handlers.PageHandler;
 import net.hillsdon.reviki.web.pages.Page;
 import net.hillsdon.reviki.web.pages.PageSource;
 import net.hillsdon.reviki.web.pages.impl.DefaultPageImpl;
 import net.hillsdon.reviki.web.redirect.RedirectToPageView;
 import net.hillsdon.reviki.web.urls.WikiUrls;
+import net.hillsdon.reviki.web.urls.impl.ResponseSessionURLOutputFilter;
+import net.hillsdon.reviki.wiki.MarkupRenderer;
+import net.hillsdon.reviki.wiki.renderer.SvnWikiRenderer;
 
 /**
  * Everything that does something to a wiki page or attachment comes through here
@@ -48,11 +58,15 @@ public class PageHandlerImpl implements PageHandler {
 
   public static final String PATH_WALK_ERROR_MESSAGE = "No '/' characters allowed in a page name.";
 
+  private final CachingPageStore _cachingPageStore;
   private final PageSource _pageSource;
+  private final MarkupRenderer<String> _renderer;
   private final WikiUrls _wikiUrls;
 
-  public PageHandlerImpl(final PageSource pageSource, final WikiUrls wikiUrls) {
+  public PageHandlerImpl(final PageSource pageSource, final WikiUrls wikiUrls, final SvnWikiRenderer renderer, CachingPageStore cachingPageStore) {
+    _cachingPageStore = cachingPageStore;
     _pageSource = pageSource;
+    _renderer = renderer;
     _wikiUrls = wikiUrls;
   }
 
@@ -66,12 +80,12 @@ public class PageHandlerImpl implements PageHandler {
     }
 
     final PageReference pageReference = new PageReferenceImpl(pageName);
+    final boolean isPost = request.getMethod().equals("POST");
     request.setAttribute("page", pageReference);
 
     final Page page = _pageSource.get(pageReference);
     if ("attachments".equals(path.peek())) {
       path.next();
-      final boolean isPost = request.getMethod().equals("POST");
       if (path.hasNext()) {
         if (isPost && request.getParameter(DefaultPageImpl.SUBMIT_DELETE) != null) {
           return page.deleteAttachment(pageReference, path, request, response);
@@ -83,6 +97,7 @@ public class PageHandlerImpl implements PageHandler {
           return page.attach(pageReference, path, request, response);
         }
         else {
+          addSideBarEtcToRequest(request, response);
           return page.attachments(pageReference, path, request, response);
         }
       }
@@ -91,9 +106,12 @@ public class PageHandlerImpl implements PageHandler {
       throw new NotFoundException();
     }
     else if (request.getParameter("history") != null) {
+      if (!ViewTypeConstants.is(request, ViewTypeConstants.CTYPE_ATOM)) {
+        addSideBarEtcToRequest(request, response);
+      }
       return page.history(pageReference, path, request, response);
     }
-    else if ("POST".equals(request.getMethod())) {
+    else if (isPost) {
       if (request.getParameter(SUBMIT_SAVE) != null
        || request.getParameter(SUBMIT_COPY) != null
        || request.getParameter(SUBMIT_RENAME) != null
@@ -101,18 +119,33 @@ public class PageHandlerImpl implements PageHandler {
         return page.set(pageReference, path, request, response);
       }
       else {
+        addSideBarEtcToRequest(request, response);
         return page.editor(pageReference, path, request, response);
       }
     }
     else {
       if (request.getParameter(SUBMIT_RENAME) != null) {
+        addSideBarEtcToRequest(request, response);
         return new JspView("Rename");
       }
       else if (request.getParameter(SUBMIT_COPY) != null) {
+        addSideBarEtcToRequest(request, response);
         return new JspView("Copy");
       }
-      return page.get(pageReference, path, request, response);
+      else {
+        if (!ViewTypeConstants.is(request, ViewTypeConstants.CTYPE_RAW)) {
+          addSideBarEtcToRequest(request, response);
+        }
+        return page.get(pageReference, path, request, response);
+      }     
     }
   }
 
+  private void addSideBarEtcToRequest(final HttpServletRequest request, final HttpServletResponse response) throws PageStoreException, IOException {
+    for (PageReference ref : COMPLIMENTARY_CONTENT_PAGES) {
+      final String requestVarName = "rendered" + ref.getPath().substring("Config".length());
+      VersionedPageInfo page = _cachingPageStore.get(ref, -1);
+      request.setAttribute(requestVarName, _renderer.render(page, new ResponseSessionURLOutputFilter(request, response)).get());
+    }
+  }
 }


### PR DESCRIPTION
Avoid creole rendering when:
* Serving a page requested with ctype=raw or a history page requested with ctype=atom
* Serving an attachment

https://jira.int.corefiling.com/browse/REVIKI-642