### PR TITLE
REVIKI-642 Avoid unnecessary creole rendering

### DIFF
--- a/WebContent/WEB-INF/templates/SiteTemplate.jsp
+++ b/WebContent/WEB-INF/templates/SiteTemplate.jsp
@@ -62,13 +62,7 @@
         <div class="row col-md-12">
           <div class="navbar-header">
             <div class="navbar-brand">
-              <c:set var="brandTitle">
-                <c:choose>
-                  <c:when test="${not empty renderedHeader}">${renderedHeader}</c:when>
-                  <c:otherwise>${renderedHeader}</c:otherwise>
-                </c:choose>
-              </c:set>
-              ${brandTitle}
+              ${renderedHeader}
             </div>
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
               <span class="sr-only">Toggle navigation</span>

--- a/WebContent/WEB-INF/templates/SiteTemplate.jsp
+++ b/WebContent/WEB-INF/templates/SiteTemplate.jsp
@@ -62,7 +62,7 @@
         <div class="row col-md-12">
           <div class="navbar-header">
             <div class="navbar-brand">
-              ${renderedHeader}
+              ${complementaryContent.renderedHeader}
             </div>
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
               <span class="sr-only">Toggle navigation</span>
@@ -112,7 +112,7 @@
           </div>
           <div class="panel-footer">
             <div id="footer" class="auxillary">
-              ${renderedFooter}
+              ${complementaryContent.renderedFooter}
               <p id="build-details">Version $Version$.</p>
             </div>
             <tiles:insertAttribute name="content-controls" ignore="true"/>

--- a/WebContent/WEB-INF/templates/ViewPage.jsp
+++ b/WebContent/WEB-INF/templates/ViewPage.jsp
@@ -43,7 +43,7 @@
   </tiles:putAttribute>
   <tiles:putAttribute name="content">
     <div id="sidebar" style="float:right">
-      ${renderedSideBar}
+      ${complementaryContent.renderedSideBar}
     </div>
 
     <div id="wiki-rendering">

--- a/renderer-src/net/hillsdon/reviki/wiki/renderer/RawRenderer.java
+++ b/renderer-src/net/hillsdon/reviki/wiki/renderer/RawRenderer.java
@@ -7,8 +7,8 @@ import java.io.UnsupportedEncodingException;
 import net.hillsdon.reviki.vc.PageInfo;
 import net.hillsdon.reviki.web.urls.URLOutputFilter;
 import net.hillsdon.reviki.wiki.MarkupRenderer;
-import net.hillsdon.reviki.wiki.renderer.creole.CreoleRenderer;
 import net.hillsdon.reviki.wiki.renderer.creole.ast.ASTNode;
+import net.hillsdon.reviki.wiki.renderer.creole.ast.Raw;
 
 /**
  * A basic renderer which just turns its input into a stream. This exploits the
@@ -23,7 +23,7 @@ public class RawRenderer extends MarkupRenderer<InputStream> {
   @Override
   public ASTNode parse(final PageInfo page) {
     _page = page;
-    return CreoleRenderer.render(page, null, null);
+    return new Raw(page.getContent());
   }
 
   @Override

--- a/webtests/net/hillsdon/reviki/webtests/TestAttachments.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestAttachments.java
@@ -16,6 +16,7 @@
 package net.hillsdon.reviki.webtests;
 
 import static net.hillsdon.reviki.web.pages.impl.DefaultPageImpl.ERROR_NO_FILE;
+import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.PAGE_HEADER;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -26,9 +27,11 @@ import java.util.Map;
 
 import net.hillsdon.reviki.vc.AttachmentHistory;
 import net.hillsdon.reviki.vc.ChangeInfo;
+import net.hillsdon.reviki.vc.PageReference;
 import net.hillsdon.reviki.vc.StoreKind;
 
 import org.apache.commons.io.IOUtils;
+
 import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.UnexpectedPage;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
@@ -186,6 +189,23 @@ public class TestAttachments extends WebTestSupport {
     // Previous version should still be available
     List<HtmlDeletedText> previousRevisions = (List<HtmlDeletedText>) attachments.getByXPath("//span[substring(text(), 1, 8)='file.txt']");
     assertEquals(1, previousRevisions.size());
+  }
+  
+  public void testAttachmentsPageContainsHeader() throws Exception {
+    // https://jira.int.corefiling.com/browse/REVIKI-642
+    // Check that the header page was added for the attachements page
+    final PageReference headerPage = PAGE_HEADER;
+    final String expect = "T" + System.currentTimeMillis() + headerPage.getPath().toLowerCase();
+    editWikiPage(headerPage.getPath(), expect, "", "Some new content", null);
+    try {
+      String name = uniqueWikiPageName("AttachmentPageHeaderTest");
+      HtmlPage edited = editWikiPage(name, "some content", "", "", true);
+      HtmlPage attachmentsPage = clickAttachmentsLink(edited, name);
+      assertTrue(attachmentsPage.asText().contains(expect));
+    }
+    finally {
+      editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
+    }
   }
 
   public void testUploadAttachmentWithDefaultMessage() throws Exception {

--- a/webtests/net/hillsdon/reviki/webtests/TestEditing.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestEditing.java
@@ -18,6 +18,8 @@ package net.hillsdon.reviki.webtests;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 
+import net.hillsdon.reviki.vc.PageReference;
+
 import org.jaxen.JaxenException;
 
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
@@ -27,6 +29,8 @@ import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
 import com.gargoylesoftware.htmlunit.html.HtmlTextArea;
+
+import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.PAGE_HEADER;
 
 public class TestEditing extends WebTestSupport {
 
@@ -77,6 +81,23 @@ public class TestEditing extends WebTestSupport {
     edited = editWikiPage(name, "Initial Status: <<attr:status>>", "", "", false);
     assertTrue(edited.asText().contains("Initial Status:"));
     assertFalse(edited.asText().contains("Initial Status: completed"));
+  }
+  
+  public void testEditPageContainsHeader() throws Exception {
+    // https://jira.int.corefiling.com/browse/REVIKI-642
+    // Check that the header page was added for the edit page
+    final PageReference headerPage = PAGE_HEADER;
+    final String expect = "T" + System.currentTimeMillis() + headerPage.getPath().toLowerCase();
+    editWikiPage(headerPage.getPath(), expect, "", "Some new content", null);
+    try {
+      String name = uniqueWikiPageName("EditPageHeaderTest");
+      HtmlPage edited = editWikiPage(name, "some content", "", "", true);
+      HtmlPage editPage = clickEditLink(edited);
+      assertTrue(editPage.asText().contains(expect));
+    }
+    finally {
+      editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
+    }
   }
   
   public void testPreviewDiffBug() throws Exception {

--- a/webtests/net/hillsdon/reviki/webtests/TestHistory.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestHistory.java
@@ -15,7 +15,11 @@
  */
 package net.hillsdon.reviki.webtests;
 
+import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.PAGE_HEADER;
+
 import java.util.List;
+
+import net.hillsdon.reviki.vc.PageReference;
 
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import com.gargoylesoftware.htmlunit.html.DomText;
@@ -36,7 +40,7 @@ public class TestHistory extends WebTestSupport {
     String pageName = uniqueWikiPageName("HistoryTest");
     HtmlPage page = editWikiPage(pageName, "Initial content", "", "", true);
     page = editWikiPage(pageName, "Altered content", "", "s/Initial/Altered", false);
-    HtmlPage history = (HtmlPage) ((HtmlAnchor) page.getByXPath("//a[@name='history']").iterator().next()).click();
+    HtmlPage history = clickHistoryLink(page);
     List<HtmlTableRow> historyRows = (List<HtmlTableRow>) history.getByXPath("//tr[td]");
     assertEquals(3, historyRows.size());
     HtmlTableRow altered = historyRows.get(1);
@@ -62,6 +66,23 @@ public class TestHistory extends WebTestSupport {
     divs = (List<HtmlDivision>) diff.getByXPath("//div[@id='flash']/.");
     assertEquals(1, divs.size());
 
+  }
+  
+  public void testHistoryPageContainsHeader() throws Exception {
+    // https://jira.int.corefiling.com/browse/REVIKI-642
+    // Check that the header page was added for the history page
+    final PageReference headerPage = PAGE_HEADER;
+    final String expect = "T" + System.currentTimeMillis() + headerPage.getPath().toLowerCase();
+    editWikiPage(headerPage.getPath(), expect, "", "Some new content", null);
+    try {
+      String name = uniqueWikiPageName("EditPageHeaderTest");
+      HtmlPage edited = editWikiPage(name, "some content", "", "", true);
+      HtmlPage historyPage = clickHistoryLink(edited);
+      assertTrue(historyPage.asText().contains(expect));
+    }
+    finally {
+      editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
+    }
   }
   
   public void testAtom() throws Exception {

--- a/webtests/net/hillsdon/reviki/webtests/TestRename.java
+++ b/webtests/net/hillsdon/reviki/webtests/TestRename.java
@@ -15,9 +15,12 @@
  */
 package net.hillsdon.reviki.webtests;
 
+import static net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences.PAGE_HEADER;
 import static net.hillsdon.reviki.webtests.TestAttachments.getTextAttachmentAtEndOfLink;
 
 import java.util.List;
+
+import net.hillsdon.reviki.vc.PageReference;
 
 import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.SVNNodeKind;
@@ -92,6 +95,23 @@ public class TestRename extends AddWikiWebTestSupport {
     // If fromPage is subsequently edited then we no longer show the notification
     fromPage = editWikiPage(fromPageName, "another edit", "", "Whatever", false);
     assertFalse(fromPage.asText().contains(toPageName));
+  }
+  
+  public void testRenamePageContainsHeader() throws Exception {
+    // https://jira.int.corefiling.com/browse/REVIKI-642
+    // Check that the header page was added for the rename page
+    final PageReference headerPage = PAGE_HEADER;
+    final String expect = "T" + System.currentTimeMillis() + headerPage.getPath().toLowerCase();
+    editWikiPage(headerPage.getPath(), expect, "", "Some new content", null);
+    try {
+      String name = uniqueWikiPageName("RenamePageHeaderTest");
+      HtmlPage edited = editWikiPage(name, "some content", "", "", true);
+      HtmlPage renamePage = (HtmlPage) edited.getAnchorByName("rename").click();
+      assertTrue(renamePage.asText().contains(expect));
+    }
+    finally {
+      editWikiPage(headerPage.getPath(), "", "", "Tidying", null);
+    }
   }
 
   private static final String DIRECTORY2 = "doesNotExist2";

--- a/webtests/net/hillsdon/reviki/webtests/WebTestSupport.java
+++ b/webtests/net/hillsdon/reviki/webtests/WebTestSupport.java
@@ -292,5 +292,9 @@ public abstract class WebTestSupport extends TestCase {
   protected HtmlPage getWikiList() throws IOException {
     return getWebPage("list");
   }
+  
+  protected HtmlPage clickHistoryLink(final HtmlPage page) throws IOException {
+    return (HtmlPage) ((HtmlAnchor) page.getByXPath("//a[@name='history']").iterator().next()).click();
+  }
 
 }

--- a/wiki-src/net/hillsdon/reviki/web/common/ComplementaryPageRenderer.java
+++ b/wiki-src/net/hillsdon/reviki/web/common/ComplementaryPageRenderer.java
@@ -1,0 +1,79 @@
+package net.hillsdon.reviki.web.common;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import net.hillsdon.reviki.vc.PageReference;
+import net.hillsdon.reviki.vc.PageStore;
+import net.hillsdon.reviki.vc.PageStoreException;
+import net.hillsdon.reviki.vc.VersionedPageInfo;
+import net.hillsdon.reviki.web.urls.impl.ResponseSessionURLOutputFilter;
+import net.hillsdon.reviki.web.vcintegration.BuiltInPageReferences;
+import net.hillsdon.reviki.wiki.MarkupRenderer;
+
+/**
+ * A class to render complementary content pages.
+ * i.e ConfigHeader, ConfigFooter and ConfigSideBar.
+ *
+ * The methods on this class are intended to be used as
+ * properties in JSP templates. Each complementary page
+ * is only rendered if its property is used by the template.
+ * This avoids unnecessary rendering.
+ *
+ * @author pwc
+ */
+public class ComplementaryPageRenderer {
+  private final MarkupRenderer<String> _renderer;
+  private final PageStore _pageStore;
+  private final HttpServletRequest _request;
+  private final HttpServletResponse _response;
+
+  public ComplementaryPageRenderer(final HttpServletRequest request, final HttpServletResponse response, final MarkupRenderer<String> renderer, final PageStore pageStore) {
+    _renderer = renderer;
+    _pageStore = pageStore;
+    _request = request;
+    _response = response;
+  }
+
+  /**
+   * Render the latest revision of a page.
+   *
+   * @param pageRef The page to render.
+   * @return The rendered page as a String.
+   * @throws PageStoreException
+   */
+  private String getRenderedPage(final PageReference pageRef) throws PageStoreException {
+    VersionedPageInfo page = _pageStore.get(pageRef, -1);
+    return _renderer.render(page, new ResponseSessionURLOutputFilter(_request, _response)).get();
+  }
+
+  /**
+   * Render the latest revision of ConfigHeader.
+   *
+   * @return The rendered ConfigHeader page as a String.
+   * @throws PageStoreException
+   */
+  public String getRenderedHeader() throws PageStoreException {
+    return getRenderedPage(BuiltInPageReferences.PAGE_HEADER);
+  }
+
+  /**
+   * Render the latest revision of ConfigFooter.
+   *
+   * @return The rendered ConfigFooter page as a String.
+   * @throws PageStoreException
+   */
+  public String getRenderedFooter() throws PageStoreException {
+    return getRenderedPage(BuiltInPageReferences.PAGE_FOOTER);
+  }
+
+  /**
+   * Render the latest revision of ConfigSideBar.
+   *
+   * @return The rendered ConfigSideBar page as a String.
+   * @throws PageStoreException
+   */
+  public String getRenderedSideBar() throws PageStoreException {
+    return getRenderedPage(BuiltInPageReferences.PAGE_SIDEBAR);
+  }
+}


### PR DESCRIPTION
Avoid creole rendering when:
* Serving a page requested with ctype=raw or a history page requested with ctype=atom
* Serving an attachment

https://jira.int.corefiling.com/browse/REVIKI-642