### PR TITLE
REVIKI-651 Make ConfigPageCachingPageStore a ChangeSubscriber that expires cache entries in response to repository changes.

### DIFF
--- a/wiki-src/net/hillsdon/reviki/vc/impl/TestConfigPageCachingPageStore.java
+++ b/wiki-src/net/hillsdon/reviki/vc/impl/TestConfigPageCachingPageStore.java
@@ -15,10 +15,15 @@
  */
 package net.hillsdon.reviki.vc.impl;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 
 import junit.framework.TestCase;
+import net.hillsdon.reviki.vc.ChangeInfo;
 import net.hillsdon.reviki.vc.PageInfo;
+import net.hillsdon.reviki.vc.VersionedPageInfo;
 import static net.hillsdon.reviki.vc.impl.ConfigPageCachingPageStore.isConfigPage;
 
 public class TestConfigPageCachingPageStore extends TestCase {
@@ -37,4 +42,99 @@ public class TestConfigPageCachingPageStore extends TestCase {
     assertFalse(store.isCached(page));
   }
 
+  public void testLockedConfigPageUsesCache() throws Exception {
+    VersionedPageInfo page = new VersionedPageInfoImpl(null, "ConfigFoo", "foo", 1, 1, "pwc", new Date(), null, null, null);
+    ConfigPageCachingPageStore store = new ConfigPageCachingPageStore(new SimplePageStore());
+    store.getUnderlying().set(page, "", 1, "Initial commit");
+    store.get(page, -1);
+
+    // Sanity check the page is cached
+    assertTrue(store.isCached(page));
+
+    // Lock the page
+    VersionedPageInfo lockedPage = new VersionedPageInfoImpl(null, "ConfigFoo", "bar", 2, 2, "pwc", new Date(), "pwc", null, null);
+
+    // Sanity check the page is locked
+    assertTrue(lockedPage.isLocked());
+
+    // Store the locked page
+    store.getUnderlying().set(lockedPage, "", 2, "Second commit");
+
+    // Sanity check that page and lockedPage have different content
+    assertFalse(lockedPage.getContent().equals(page.getContent()));
+
+    // We should get the cached page when fetching the page referenced by
+    // the locked page.
+    VersionedPageInfo cachedPage = store.get(lockedPage, -1);
+    assertTrue(cachedPage.getContent().equals(page.getContent()));
+
+    // Sanity check expiring the page referenced by the lockedPage
+    // and retrieving the lockedPage from the store.
+    store.expire(lockedPage);
+    VersionedPageInfo afterExpire = store.get(lockedPage, -1);
+    assertTrue(afterExpire.getContent().equals(lockedPage.getContent()));
+  }
+
+  public void testSpecialRevisionIsNotCached() throws Exception {
+    PageInfo page = new PageInfoImpl(null, "ConfigFoo", "Hey there", Collections.<String, String>emptyMap());
+    ConfigPageCachingPageStore store = new ConfigPageCachingPageStore(new SimplePageStore());
+
+    // This should not cache the page
+    VersionedPageInfo uncommittedPage = store.get(page, -1);
+
+    // Sanity check the uncommmitted revision
+    assertTrue(uncommittedPage.getRevision() == -2L);
+
+    // Store the page, we should retrieve page from the cache.
+    store.getUnderlying().set(page, "", 1, "Initial commit");
+    VersionedPageInfo cachedPage = store.get(page, -1);
+    assertTrue(cachedPage.getContent().equals(page.getContent()));
+  }
+
+  public void testChangesExpireCache() throws Exception {
+    // Cache a page
+    PageInfo page = new PageInfoImpl(null, "ConfigFoo", "Hey there", Collections.<String, String>emptyMap());
+    ConfigPageCachingPageStore store = new ConfigPageCachingPageStore(new SimplePageStore());
+    store.getUnderlying().set(page, "", 1, "Initial commit");
+    store.get(page, -1);
+    assertTrue(store.isCached(page));
+
+    // Assemble a change for the page
+    List<ChangeInfo> changes = new ArrayList<ChangeInfo>();
+    changes.add(new ChangeInfo(page.getName(), page.getName(), "pwc", new Date(), 3L, "Second revision", null, null, null, -2));
+
+    // Call handleChanges, should expire the cache
+    store.handleChanges(3L, changes);
+    assertFalse(store.isCached(page));
+  }
+
+  public void testChangeToOtherPageDoesNotExpireCache() throws Exception {
+    // Cache a page
+    PageInfo page = new PageInfoImpl(null, "ConfigFoo", "Hey there", Collections.<String, String>emptyMap());
+    ConfigPageCachingPageStore store = new ConfigPageCachingPageStore(new SimplePageStore());
+    store.getUnderlying().set(page, "", 1, "Initial commit");
+    store.get(page, -1);
+    assertTrue(store.isCached(page));
+
+    // Assemble a change for the page
+    List<ChangeInfo> changes = new ArrayList<ChangeInfo>();
+    changes.add(new ChangeInfo("ConfigBar", "ConfigBar", "pwc", new Date(), 3L, "Second revision", null, null, null, -2));
+
+    // Call handleChanges, should not expire the cache
+    store.handleChanges(3L, changes);
+    assertTrue(store.isCached(page));
+  }
+
+  public void testChangesUpdateHighestSyncedRevision() throws Exception {
+    ConfigPageCachingPageStore store = new ConfigPageCachingPageStore(new SimplePageStore());
+    // Assemble a change for the page
+    List<ChangeInfo> changes = new ArrayList<ChangeInfo>();
+    changes.add(new ChangeInfo("ConfigBar", "ConfigBar", "pwc", new Date(), 3L, "Second revision", null, null, null, -2));
+    changes.add(new ChangeInfo("ConfigBar", "ConfigBar", "pwc", new Date(), 4L, "Second revision", null, null, null, -2));
+    changes.add(new ChangeInfo("ConfigBar", "ConfigBar", "pwc", new Date(), 43L, "Second revision", null, null, null, -2));
+
+    store.handleChanges(43L, changes);
+
+    assertTrue(store.getHighestSyncedRevision() == 43L);
+  }
 }


### PR DESCRIPTION
Previously a locked ConfigPage was always fetched from the external
repository which affected performance. Especially when
ConfigInterWikiLinks was locked.

The purpose of ConfigPageCachingPageStore.handleChanges is to expire
cached pages that have changed. When the cache is empty it does not
need to handle changes and so getHighestSyncedRevision() returns an
integer indicating to the change dispatcher that it doesn't need to be
sent changes.

https://jira.int.corefiling.com/browse/REVIKI-651