### PR TITLE
REVIKI-651 Make ConfigPageCachingPageStore cache default versions of Config pages.

### DIFF
--- a/wiki-src/net/hillsdon/reviki/vc/impl/ConfigPageCachingPageStore.java
+++ b/wiki-src/net/hillsdon/reviki/vc/impl/ConfigPageCachingPageStore.java
@@ -63,15 +63,11 @@ public class ConfigPageCachingPageStore extends SimpleDelegatingPageStore implem
       // NB. revision is one of -1, -2, -3, -4. See VersionedPageInfoImpl
       synchronized (this) {
         long pageRev = pageInfo.getRevision();
-        // If pageRev is one of -2, -3 -4 (see VersionedPageInfoImpl)
-        // then the default version of the ConfigPage is used. i.e
-        // it is not fetched from SVN so there's no need to cache it.
-        if (pageRev > -1) {
-          _cache.put(ref, pageInfo);
-          LOG.debug("Caching: " + ref.getPath() + " Revision: " + Long.toString(pageRev));
-          if (pageRev <= _lowestUnsyncedRevision) {
-            _lowestUnsyncedRevision = pageRev + 1;
-          }
+        LOG.debug("Caching: " + ref.getPath() + " Revision: " + Long.toString(pageRev));
+        _cache.put(ref, pageInfo);
+        // Do not record reviki internal revisions (one of -1. -2. -3. -4 see VersionedPageInfoImpl).
+        if (pageRev >= 0 && pageRev <= _lowestUnsyncedRevision) {
+          _lowestUnsyncedRevision = pageRev + 1;
         }
       }
     }

--- a/wiki-src/net/hillsdon/reviki/vc/impl/TestConfigPageCachingPageStore.java
+++ b/wiki-src/net/hillsdon/reviki/vc/impl/TestConfigPageCachingPageStore.java
@@ -75,20 +75,20 @@ public class TestConfigPageCachingPageStore extends TestCase {
     assertTrue(afterExpire.getContent().equals(lockedPage.getContent()));
   }
 
-  public void testSpecialRevisionIsNotCached() throws Exception {
+  public void testSpecialRevisionIsCached() throws Exception {
     PageInfo page = new PageInfoImpl(null, "ConfigFoo", "Hey there", Collections.<String, String>emptyMap());
     ConfigPageCachingPageStore store = new ConfigPageCachingPageStore(new SimplePageStore());
 
-    // This should not cache the page
+    // Cache the page
     VersionedPageInfo uncommittedPage = store.get(page, -1);
 
     // Sanity check the uncommmitted revision
     assertTrue(uncommittedPage.getRevision() == -2L);
 
-    // Store the page, we should retrieve page from the cache.
-    store.getUnderlying().set(page, "", 1, "Initial commit");
-    VersionedPageInfo cachedPage = store.get(page, -1);
-    assertTrue(cachedPage.getContent().equals(page.getContent()));
+    assertTrue(store.isCached(uncommittedPage));
+
+    // Check that the highestSyncedRevision was not set to the internal revision
+    assertTrue(store.getHighestSyncedRevision() > 0);
   }
 
   public void testChangesExpireCache() throws Exception {


### PR DESCRIPTION
If the PageStore returns a ConfigPage with an internal reviki revision
(-2, -3, -4) then the default (i.e non-repository) version of the page
is used. This should be put in the cache.

The internal revision should not be be used to get SVN changes as a
ChangeSubscriber.

https://jira.int.corefiling.com/browse/REVIKI-651